### PR TITLE
Add logic and UI for auth flow in frontend application

### DIFF
--- a/dashboard-ui/.gitignore
+++ b/dashboard-ui/.gitignore
@@ -19,6 +19,7 @@ package-lock.json
 .env.development.local
 .env.test.local
 .env.production.local
+.tool-versions
 
 npm-debug.log*
 yarn-debug.log*

--- a/dashboard-ui/db.js
+++ b/dashboard-ui/db.js
@@ -177,7 +177,7 @@ function getPlayerData(numPlayers, numAttributes, nationsList) {
                 history: abilityHistory
             }
 
-        }
+        };
 
         playerData.push(player);
     }
@@ -223,10 +223,29 @@ function getPlayerPerformanceData(playerData, numCompetitions, numMatches) {
     return performanceData;
 }
 
+function getUserData(numUsers) {
+    const userData = [];
+    for (let i = 0; i < numUsers; i++) {
+        userData.push({
+            firstName: faker.name.firstName(),
+            lastName: faker.name.lastName(),
+            email: faker.internet.email(),
+            password: faker.internet.password()
+        });
+    }
+    return userData;
+}
+
 module.exports = () => {
     const playerData = getPlayerData(100, 3 * 10, nations);
     const squadPlayerData = getSquadHubPlayerData(playerData, 10, moraleList);
     const playerPerformanceData = getPlayerPerformanceData(playerData, 5, 10);
-    const data = { players: playerData, squadPlayers: squadPlayerData, performance: playerPerformanceData };
+    const userData = getUserData(100);
+    const data = {
+        players: playerData,
+        squadPlayers: squadPlayerData,
+        performance: playerPerformanceData,
+        users: userData
+    };
     return data;
-}
+};

--- a/dashboard-ui/db.js
+++ b/dashboard-ui/db.js
@@ -230,7 +230,8 @@ function getUserData(numUsers) {
             firstName: faker.name.firstName(),
             lastName: faker.name.lastName(),
             email: faker.internet.email(),
-            password: faker.internet.password()
+            password: faker.internet.password(),
+            authToken: faker.random.uuid()
         });
     }
     return userData;

--- a/dashboard-ui/db.js
+++ b/dashboard-ui/db.js
@@ -227,6 +227,7 @@ function getUserData(numUsers) {
     const userData = [];
     for (let i = 0; i < numUsers; i++) {
         userData.push({
+            id: i,
             firstName: faker.name.firstName(),
             lastName: faker.name.lastName(),
             email: faker.internet.email(),

--- a/dashboard-ui/src/App.js
+++ b/dashboard-ui/src/App.js
@@ -5,26 +5,32 @@ import { ReactQueryDevtools } from 'react-query/devtools';
 
 import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 
-
 import Layout from './Layout';
 import { useThemePreference } from './context/themePreferenceProvider';
 import { ChartOptionsProvider } from './context/chartOptionsProvider';
+import { AuthContextProvider } from './context/authProvider';
 
 function App() {
     const queryClient = new QueryClient();
     const themePreference = useThemePreference();
-    const theme = React.useMemo(() => createMuiTheme({
-        palette: {
-            type: themePreference
-        }
-    }), [themePreference]);
+    const theme = React.useMemo(
+        () =>
+            createMuiTheme({
+                palette: {
+                    type: themePreference,
+                },
+            }),
+        [themePreference]
+    );
 
     return (
         <Router>
-            <QueryClientProvider client={ queryClient }>
-                <ThemeProvider theme={ theme }>
+            <QueryClientProvider client={queryClient}>
+                <ThemeProvider theme={theme}>
                     <ChartOptionsProvider>
-                        <Layout />
+                        <AuthContextProvider>
+                            <Layout />
+                        </AuthContextProvider>
                     </ChartOptionsProvider>
                 </ThemeProvider>
                 <ReactQueryDevtools initialIsOpen={false} />

--- a/dashboard-ui/src/Layout.js
+++ b/dashboard-ui/src/Layout.js
@@ -99,7 +99,7 @@ const AppContainer = ({ classes }) => {
 };
 
 AppContainer.propTypes = {
-    classes: PropTypes.node
+    classes: PropTypes.object
 };
 
 export default function Layout() {

--- a/dashboard-ui/src/Layout.js
+++ b/dashboard-ui/src/Layout.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import CssBaseline from '@material-ui/core/CssBaseline';
 
@@ -11,7 +12,7 @@ import { makeStyles } from '@material-ui/core';
 import { useUserAuth } from './context/authProvider';
 import UserAuth from './pages/UserAuth';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(theme => ({
     root: {
         display: 'flex'
     },
@@ -78,6 +79,10 @@ const AppContainer = ({ classes }) => {
             </main>
         </>
     );
+};
+
+AppContainer.propTypes = {
+    classes: PropTypes.node
 };
 
 export default function Layout() {

--- a/dashboard-ui/src/Layout.js
+++ b/dashboard-ui/src/Layout.js
@@ -39,6 +39,11 @@ const useStyles = makeStyles(theme => ({
         width: '200px !important',
         height: '200px !important',
         margin: '35vh'
+    },
+    formContainer: {
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center'
     }
 }));
 

--- a/dashboard-ui/src/Layout.js
+++ b/dashboard-ui/src/Layout.js
@@ -1,16 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link, Route, Switch } from 'react-router-dom';
 
 import CssBaseline from '@material-ui/core/CssBaseline';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { makeStyles } from '@material-ui/core/styles';
 
 import AppBarMenu from './components/AppBarMenu';
 import Sidebar from './widgets/Sidebar';
-
-import routingData from './routingData';
-import { Link, Route, Switch } from 'react-router-dom';
-import { makeStyles } from '@material-ui/core';
-import { useUserAuth } from './context/authProvider';
 import UserAuth from './pages/UserAuth';
+import routingData from './routingData';
+import { useUserAuth } from './context/authProvider';
+import useUserData from './hooks/useUserData';
 
 const useStyles = makeStyles(theme => ({
     root: {
@@ -27,6 +28,17 @@ const useStyles = makeStyles(theme => ({
         padding: theme.spacing(0, 1),
         // necessary for content to be below app bar
         ...theme.mixins.toolbar
+    },
+    loadingCircleRoot: {
+        display: 'flex',
+        flexDirection: 'column',
+        flexGrow: 1,
+        alignItems: 'center'
+    },
+    loadingCircle: {
+        width: '200px !important',
+        height: '200px !important',
+        margin: '35vh'
     }
 }));
 
@@ -88,12 +100,21 @@ AppContainer.propTypes = {
 export default function Layout() {
     const classes = useStyles();
 
-    const userAuth = useUserAuth();
+    const { authToken } = useUserAuth();
+    const { isLoading, isLoggedIn } = useUserData(authToken);
 
     return (
         <div className={classes.root}>
             <CssBaseline />
-            {userAuth.currentUser ? <AppContainer classes={classes} /> : <UserAuth classes={classes} />}
+            {isLoading ? (
+                <div className={classes.loadingCircleRoot}>
+                    <CircularProgress className={classes.loadingCircle} />
+                </div>
+            ) : isLoggedIn ? (
+                <AppContainer classes={classes} />
+            ) : (
+                <UserAuth classes={classes} />
+            )}
         </div>
     );
 }

--- a/dashboard-ui/src/Layout.js
+++ b/dashboard-ui/src/Layout.js
@@ -8,6 +8,8 @@ import Sidebar from './widgets/Sidebar';
 import routingData from './routingData';
 import { Link, Route, Switch } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core';
+import { useUserAuth } from './context/authProvider';
+import UserAuth from './pages/UserAuth';
 
 const useStyles = makeStyles((theme) => ({
     root: {
@@ -27,9 +29,7 @@ const useStyles = makeStyles((theme) => ({
     }
 }));
 
-export default function Layout() {
-    const classes = useStyles();
-
+const AppContainer = ({ classes }) => {
     const [open, setOpen] = React.useState(false);
 
     const handleDrawerOpen = () => {
@@ -40,7 +40,8 @@ export default function Layout() {
         setOpen(false);
     };
 
-    const sideBarItems = routingData.filter(sidebarItem => sidebarItem.showInSidebar)
+    const sideBarItems = routingData
+        .filter(sidebarItem => sidebarItem.showInSidebar)
         .map((sidebarItemData, _idx) => ({
             isGroup: false,
             listItem: {
@@ -57,36 +58,37 @@ export default function Layout() {
         title: 'Dummy App Bar Menu Title',
         teamColor: 'red'
     };
-
     return (
-        <div className={ classes.root }>
-            <CssBaseline />
-            <AppBarMenu
-                menu={{ ...menuData }}
-                isOpen={ open }
-                onClickHandler={ handleDrawerOpen }
-            />
-            <Sidebar
-                sideBarItems={ sideBarItems }
-                isOpen={ open }
-                onClickHandler={ handleDrawerClose }
-            />
-            <main className={ classes.content }>
-                <div className={ classes.view }>
+        <>
+            <AppBarMenu menu={{ ...menuData }} isOpen={open} onClickHandler={handleDrawerOpen} />
+            <Sidebar sideBarItems={sideBarItems} isOpen={open} onClickHandler={handleDrawerClose} />
+            <main className={classes.content}>
+                <div className={classes.view}>
                     <Switch>
-                        {
-                            routingData.map((sidebarItemData, _idx) => (
-                                <Route exact={ sidebarItemData.isExact }
-                                    key={ _idx }
-                                    path={ sidebarItemData.routePath }
-                                    component={ sidebarItemData.component }
-                                />
-                            ))
-                        }
+                        {routingData.map((sidebarItemData, _idx) => (
+                            <Route
+                                exact={sidebarItemData.isExact}
+                                key={_idx}
+                                path={sidebarItemData.routePath}
+                                component={sidebarItemData.component}
+                            />
+                        ))}
                     </Switch>
                 </div>
             </main>
+        </>
+    );
+};
+
+export default function Layout() {
+    const classes = useStyles();
+
+    const userAuth = useUserAuth();
+
+    return (
+        <div className={classes.root}>
+            <CssBaseline />
+            {userAuth.currentUser ? <AppContainer classes={classes} /> : <UserAuth classes={classes} />}
         </div>
     );
-
 }

--- a/dashboard-ui/src/clients/DashboardClient.js
+++ b/dashboard-ui/src/clients/DashboardClient.js
@@ -32,10 +32,12 @@ export const fetchPlayerPerformanceData = async ({ queryKey }) => {
 };
 
 export const authenticateUser = async ({ username, password }) => {
-    const userData = await fetchDataFromEndpoint(`users?username=${username}&password=${password}`);
+    const userData = await fetchDataFromEndpoint(`users?email=${username}&password=${password}`);
     if (userData.length > 0) {
         const { authToken } = userData[0];
         return authToken;
+    } else {
+        throw new Error(`Unable to find account with email: ${username}!`)
     }
 };
 
@@ -56,10 +58,18 @@ export const fetchUser = async ({ queryKey }) => {
     }
 };
 
-export const createUser = async (createdUserData) => {
+export const createUser = async (newUserData) => {
+    const { email } = newUserData;
+    // check for existing user via email manually
+    // TODO: remove this when integrating with backend as duplicate user validation is baked in
+    const existingUser = await fetchDataFromEndpoint(`users?email=${email}`);
+    if (existingUser.length > 0 && existingUser[0]) {
+        throw new Error(`User with email address: ${email}, already exists!`);
+    }
+
     const res = await fetch(`${baseUrl}users/`, {
         method: 'POST',
-        body: JSON.stringify(createdUserData),
+        body: JSON.stringify(newUserData),
         headers: { 'Content-Type': 'application/json' }
     });
     return await res.json();

--- a/dashboard-ui/src/clients/DashboardClient.js
+++ b/dashboard-ui/src/clients/DashboardClient.js
@@ -37,7 +37,7 @@ export const authenticateUser = async ({ username, password }) => {
         const { authToken } = userData[0];
         return authToken;
     } else {
-        throw new Error(`Unable to find account with email: ${username}!`)
+        throw new Error(`Unable to find account with email: ${username}!`);
     }
 };
 

--- a/dashboard-ui/src/clients/DashboardClient.js
+++ b/dashboard-ui/src/clients/DashboardClient.js
@@ -31,6 +31,20 @@ export const fetchPlayerPerformanceData = async ({ queryKey }) => {
 
 };
 
+export const fetchUser = async ({ queryKey }) => {
+    const [ _key, { email, password }] = queryKey;
+    return await fetchDataFromEndpoint(`users?email=${email}&password=${password}`);
+};
+
+export const createUser = async (createdUserData) => {
+    const res = await fetch(`${baseUrl}users/`, {
+        method: 'POST',
+        body: JSON.stringify(createdUserData),
+        headers: { 'Content-Type': 'application/json' }
+    });
+    return res.json();
+};
+
 async function fetchDataFromEndpoint(endpointFragment) {
     const res = await fetch(`${baseUrl}${endpointFragment}`);
 

--- a/dashboard-ui/src/components/Alert.js
+++ b/dashboard-ui/src/components/Alert.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+
+import { fade, makeStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+
+const useStyles = makeStyles((theme) => ({
+    root: {
+        marginTop: theme.spacing(1),
+        padding: theme.spacing(2),
+        borderRadius: '4px',
+        textAlign: 'center'
+    },
+    success: {
+        color: theme.palette.success.dark,
+        backgroundColor: fade(theme.palette.success.light, 0.3),
+        border: `1px solid ${theme.palette.success.dark}`
+    },
+    error: {
+        color: theme.palette.error.dark,
+        backgroundColor: fade(theme.palette.error.light, 0.3),
+        border: `1px solid ${theme.palette.error.dark}`
+    }
+}));
+
+export default function Alert({ severity, text }) {
+    const classes = useStyles();
+    return (
+        <div className={clsx(classes.root, {
+            [classes.success]: severity === 'success',
+            [classes.error]: severity === 'error' })}>
+            <Typography component='p'>
+                { text }
+            </Typography>
+        </div>
+    );
+}
+
+Alert.propTypes = {
+    severity: PropTypes.string,
+    text: PropTypes.string
+};

--- a/dashboard-ui/src/components/AppBarMenu.js
+++ b/dashboard-ui/src/components/AppBarMenu.js
@@ -6,11 +6,15 @@ import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 import IconButton from '@material-ui/core/IconButton';
+import Menu from '@material-ui/core/Menu';
 import MenuIcon from '@material-ui/icons/Menu';
 import SearchIcon from '@material-ui/icons/Search';
 import InputBase from '@material-ui/core/InputBase';
 import { fade, makeStyles } from '@material-ui/core/styles';
 import { DRAWER_WIDTH } from '../utils';
+import { MenuItem } from '@material-ui/core';
+import { AccountCircleSharp } from '@material-ui/icons';
+import { useUserAuth } from '../context/authProvider';
 
 const useStyles = makeStyles((theme) => ({
     grow: {
@@ -20,7 +24,7 @@ const useStyles = makeStyles((theme) => ({
         zIndex: theme.zIndex.drawer + 1,
         transition: theme.transitions.create(['width', 'margin'], {
             easing: theme.transitions.easing.sharp,
-            duration: theme.transitions.duration.leavingScreen,
+            duration: theme.transitions.duration.leavingScreen
         })
     },
     appBarShift: {
@@ -28,20 +32,20 @@ const useStyles = makeStyles((theme) => ({
         width: `calc(100% - ${DRAWER_WIDTH}px)`,
         transition: theme.transitions.create(['width', 'margin'], {
             easing: theme.transitions.easing.sharp,
-            duration: theme.transitions.duration.enteringScreen,
+            duration: theme.transitions.duration.enteringScreen
         })
     },
     hide: {
         display: 'none'
     },
     menuButton: {
-        marginRight: theme.spacing(2),
+        marginRight: theme.spacing(2)
     },
     title: {
         display: 'none',
         [theme.breakpoints.up('sm')]: {
-            display: 'block',
-        },
+            display: 'block'
+        }
     },
     search: {
         position: 'relative',
@@ -51,12 +55,12 @@ const useStyles = makeStyles((theme) => ({
         width: '100%',
         backgroundColor: fade(theme.palette.common.white, 0.15),
         '&:hover': {
-            backgroundColor: fade(theme.palette.common.white, 0.25),
+            backgroundColor: fade(theme.palette.common.white, 0.25)
         },
         [theme.breakpoints.up('sm')]: {
             marginLeft: theme.spacing(3),
-            width: 'auto',
-        },
+            width: 'auto'
+        }
     },
     searchIcon: {
         padding: theme.spacing(0, 2),
@@ -65,10 +69,10 @@ const useStyles = makeStyles((theme) => ({
         pointerEvents: 'none',
         display: 'flex',
         alignItems: 'center',
-        justifyContent: 'center',
+        justifyContent: 'center'
     },
     inputRoot: {
-        color: 'inherit',
+        color: 'inherit'
     },
     inputInput: {
         padding: theme.spacing(1, 1, 1, 0),
@@ -77,57 +81,84 @@ const useStyles = makeStyles((theme) => ({
         transition: theme.transitions.create('width'),
         width: '100%',
         [theme.breakpoints.up('md')]: {
-            width: '20ch',
-        },
-    },
+            width: '20ch'
+        }
+    }
 }));
 
 export default function AppBarMenu({ menu: { title, teamColor }, onClickHandler, isOpen }) {
     const classes = useStyles();
+    const [menuAnchor, setMenuAnchor] = React.useState(null);
+    const isMenuOpen = Boolean(menuAnchor);
+    const { logOut } = useUserAuth();
 
-    const teamStyle = {
-        backgroundColor: teamColor
+    const handleMenuOpen = e => {
+        setMenuAnchor(e.currentTarget);
     };
 
-    return (
-        <AppBar
-            style={teamStyle}
-            className={
-                clsx(classes.appBar, {
-                    [classes.appBarShift]: isOpen
-                })
-            }
-            position="fixed"
+    const handleMenuClose = () => {
+        setMenuAnchor(null);
+    };
+
+    const renderUserMenu = (
+        <Menu
+            keepMounted
+            anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+            transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+            open={isMenuOpen}
+            anchorEl={menuAnchor}
+            onClose={handleMenuClose}
         >
-            <Toolbar>
-                <IconButton
-                    edge="start"
-                    className={
-                        clsx(classes.menuButton, {
+            <MenuItem onClick={handleMenuClose}>Profile</MenuItem>
+            <MenuItem onClick={logOut}>Log Out</MenuItem>
+        </Menu>
+    );
+
+    return (
+        <>
+            <AppBar
+                style={{ backgroundColor: teamColor }}
+                className={clsx(classes.appBar, {
+                    [classes.appBarShift]: isOpen
+                })}
+                position='fixed'
+            >
+                <Toolbar>
+                    <IconButton
+                        edge='start'
+                        className={clsx(classes.menuButton, {
                             [classes.hide]: isOpen
                         })}
-                    color="inherit"
-                    onClick={  onClickHandler }
-                >
-                    <MenuIcon/>
-                </IconButton>
-                <Typography variant="h6" className={classes.title} noWrap>
-                    { title }
-                </Typography>
-                <div className={classes.search}>
-                    <div className={classes.searchIcon}>
-                        <SearchIcon />
+                        color='inherit'
+                        onClick={onClickHandler}
+                    >
+                        <MenuIcon />
+                    </IconButton>
+                    <Typography variant='h6' className={classes.title} noWrap>
+                        {title}
+                    </Typography>
+                    <div className={classes.search}>
+                        <div className={classes.searchIcon}>
+                            <SearchIcon />
+                        </div>
+                        <InputBase
+                            placeholder='Search players ...'
+                            classes={{
+                                root: classes.inputRoot,
+                                input: classes.inputInput
+                            }}
+                        />
                     </div>
-                    <InputBase
-                        placeholder="Search players ..."
-                        classes={{
-                            root: classes.inputRoot,
-                            input: classes.inputInput
-                        }}
-                    />
-                </div>
-            </Toolbar>
-        </AppBar>
+                    <div style={{ flexGrow: 1 }} />
+                    <div style={{ display: 'flex' }}>
+                        <IconButton color='inherit' onClick={handleMenuOpen}>
+                            <AccountCircleSharp />
+                        </IconButton>
+                    </div>
+                </Toolbar>
+            </AppBar>
+            {renderUserMenu}
+        </>
     );
 }
 

--- a/dashboard-ui/src/components/MenuItem.js
+++ b/dashboard-ui/src/components/MenuItem.js
@@ -27,11 +27,11 @@ export default function MenuItem({ text, icon, clsName, selectedItem, menuItemIn
 
 MenuItem.propTypes = {
     text: PropTypes.string,
-    icon: PropTypes.elementType,
+    icon: PropTypes.node,
     clsName: PropTypes.string,
     selectedItem: PropTypes.number,
     menuItemIndex: PropTypes.number,
     handleMenuItemClick: PropTypes.func,
-    componentType: PropTypes.element,
+    componentType: PropTypes.elementType,
     routePath: PropTypes.string
 };

--- a/dashboard-ui/src/components/SignIn.js
+++ b/dashboard-ui/src/components/SignIn.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link as RouterLink } from 'react-router-dom';
 
 import Avatar from '@material-ui/core/Avatar';
 import Button from '@material-ui/core/Button';
@@ -40,18 +41,18 @@ const useStyles = makeStyles((theme) => ({
 export default function SignIn({ values, handleChange, handleSubmit, validations, submitStatus }) {
     const classes = useStyles();
     return (
-        <div className={ classes.paper }>
-            <Avatar  className={ classes.avatar }>
+        <div className={classes.paper}>
+            <Avatar className={classes.avatar}>
                 <LockOutlinedIcon />
             </Avatar>
             <Typography component='h1' variant='h5'>
                 Sign In
             </Typography>
-            <div className={ classes.validations }>
-                { submitStatus === 'SUBMITTED' && <Alert severity='success' text='Signed In Successfully!' /> }
-                { validations.form != null && <Alert severity='error' text={validations.form} /> }
+            <div className={classes.validations}>
+                {submitStatus === 'SUBMITTED' && <Alert severity='success' text='Signed In Successfully!' />}
+                {validations.form != null && <Alert severity='error' text={validations.form} />}
             </div>
-            <form className={ classes.form } onSubmit={ handleSubmit } noValidate>
+            <form className={classes.form} onSubmit={handleSubmit} noValidate>
                 <TextField
                     name='email'
                     required
@@ -62,11 +63,11 @@ export default function SignIn({ values, handleChange, handleSubmit, validations
                     type='email'
                     fullWidth
                     autoFocus
-                    value={ values.email }
-                    disabled={ submitStatus === 'SUBMITTING' }
-                    onChange={ e => handleChange(e) }
-                    error={ validations.email != null }
-                    helperText={ validations.email }
+                    value={values.email}
+                    disabled={submitStatus === 'SUBMITTING'}
+                    onChange={e => handleChange(e)}
+                    error={validations.email != null}
+                    helperText={validations.email}
                 />
                 <TextField
                     name='password'
@@ -78,25 +79,25 @@ export default function SignIn({ values, handleChange, handleSubmit, validations
                     type='password'
                     fullWidth
                     autoComplete='current-password'
-                    value={ values.password }
-                    disabled={ submitStatus === 'SUBMITTING' }
-                    onChange={ e => handleChange(e) }
-                    error={ validations.password != null }
-                    helperText={ validations.password }
+                    value={values.password}
+                    disabled={submitStatus === 'SUBMITTING'}
+                    onChange={e => handleChange(e)}
+                    error={validations.password != null}
+                    helperText={validations.password}
                 />
                 <FormControlLabel
-                    control={<Checkbox value="remember" color="primary" disabled={ submitStatus === 'SUBMITTING' }/>}
-                    label="Remember me"
+                    control={<Checkbox value='remember' color='primary' disabled={submitStatus === 'SUBMITTING'} />}
+                    label='Remember me'
                 />
                 <Button
-                    className={ classes.submit }
+                    className={classes.submit}
                     type='submit'
                     variant='contained'
                     color='primary'
                     fullWidth
-                    disabled={ submitStatus === 'SUBMITTING' }
+                    disabled={submitStatus === 'SUBMITTING'}
                 >
-                    { submitStatus === 'SUBMITTING' ? 'Signing In ...' : 'Sign In' }
+                    {submitStatus === 'SUBMITTING' ? 'Signing In ...' : 'Sign In'}
                 </Button>
                 <Grid container>
                     <Grid item xs>
@@ -105,7 +106,7 @@ export default function SignIn({ values, handleChange, handleSubmit, validations
                         </Link>
                     </Grid>
                     <Grid item>
-                        <Link to='/signUp' variant="body2">
+                        <Link to='/signUp' component={RouterLink} variant='body2'>
                             Don&apos;t have an account? Sign Up
                         </Link>
                     </Grid>

--- a/dashboard-ui/src/components/SignIn.js
+++ b/dashboard-ui/src/components/SignIn.js
@@ -20,7 +20,13 @@ const useStyles = makeStyles((theme) => ({
         display: 'flex',
         marginTop: theme.spacing(8),
         flexDirection: 'column',
-        alignItems: 'center'
+        alignItems: 'center',
+        width: '50%',
+        borderColor: theme.palette.divider,
+        borderStyle: 'solid',
+        borderWidth: '1px',
+        borderRadius: '5px',
+        padding: theme.spacing(3, 2)
     },
     avatar: {
         margin: theme.spacing(1),

--- a/dashboard-ui/src/components/SignIn.js
+++ b/dashboard-ui/src/components/SignIn.js
@@ -5,8 +5,8 @@ import { Link as RouterLink } from 'react-router-dom';
 import Avatar from '@material-ui/core/Avatar';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Checkbox from '@material-ui/core/Checkbox';
+// import FormControlLabel from '@material-ui/core/FormControlLabel';
+// import Checkbox from '@material-ui/core/Checkbox';
 import Link from '@material-ui/core/Link';
 import Grid from '@material-ui/core/Grid';
 import LockOutlinedIcon from '@material-ui/icons/LockOutlined';
@@ -85,10 +85,11 @@ export default function SignIn({ values, handleChange, handleSubmit, validations
                     error={validations.password != null}
                     helperText={validations.password}
                 />
-                <FormControlLabel
+                {/* // TODO: uncomment when Remember Me functionality is ready */}
+                {/* <FormControlLabel
                     control={<Checkbox value='remember' color='primary' disabled={submitStatus === 'SUBMITTING'} />}
                     label='Remember me'
-                />
+                /> */}
                 <Button
                     className={classes.submit}
                     type='submit'
@@ -100,11 +101,12 @@ export default function SignIn({ values, handleChange, handleSubmit, validations
                     {submitStatus === 'SUBMITTING' ? 'Signing In ...' : 'Sign In'}
                 </Button>
                 <Grid container>
-                    <Grid item xs>
+                    {/* // TODO: uncomment when forgot password functionality is ready */}
+                    {/* <Grid item xs>
                         <Link href='/forgotPassword' variant='body2'>
                             Forgot password?
                         </Link>
-                    </Grid>
+                    </Grid> */}
                     <Grid item>
                         <Link to='/signUp' component={RouterLink} variant='body2'>
                             Don&apos;t have an account? Sign Up

--- a/dashboard-ui/src/components/SignIn.js
+++ b/dashboard-ui/src/components/SignIn.js
@@ -1,0 +1,131 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Avatar from '@material-ui/core/Avatar';
+import Button from '@material-ui/core/Button';
+import TextField from '@material-ui/core/TextField';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Checkbox from '@material-ui/core/Checkbox';
+import Link from '@material-ui/core/Link';
+import Grid from '@material-ui/core/Grid';
+import LockOutlinedIcon from '@material-ui/icons/LockOutlined';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
+
+import Alert from './Alert';
+
+const useStyles = makeStyles((theme) => ({
+    paper: {
+        display: 'flex',
+        marginTop: theme.spacing(8),
+        flexDirection: 'column',
+        alignItems: 'center'
+    },
+    avatar: {
+        margin: theme.spacing(1),
+        backgroundColor: theme.palette.secondary.main
+    },
+    form: {
+        width: '100%',
+        marginTop: theme.spacing(1)
+    },
+    submit: {
+        margin: theme.spacing(3, 0, 2)
+    },
+    validations: {
+        width: '100%'
+    }
+}));
+
+export default function SignIn({ values, handleChange, handleSubmit, validations, submitStatus }) {
+    const classes = useStyles();
+    return (
+        <div className={ classes.paper }>
+            <Avatar  className={ classes.avatar }>
+                <LockOutlinedIcon />
+            </Avatar>
+            <Typography component='h1' variant='h5'>
+                Sign In
+            </Typography>
+            <div className={ classes.validations }>
+                { submitStatus === 'SUBMITTED' && <Alert severity='success' text='Signed In Successfully!' /> }
+                { validations.form != null && <Alert severity='error' text={validations.form} /> }
+            </div>
+            <form className={ classes.form } onSubmit={ handleSubmit } noValidate>
+                <TextField
+                    name='email'
+                    required
+                    id='email'
+                    label='Email Address'
+                    variant='outlined'
+                    margin='normal'
+                    type='email'
+                    fullWidth
+                    autoFocus
+                    value={ values.email }
+                    disabled={ submitStatus === 'SUBMITTING' }
+                    onChange={ e => handleChange(e) }
+                    error={ validations.email != null }
+                    helperText={ validations.email }
+                />
+                <TextField
+                    name='password'
+                    required
+                    id='password'
+                    label='Password'
+                    variant='outlined'
+                    margin='normal'
+                    type='password'
+                    fullWidth
+                    autoComplete='current-password'
+                    value={ values.password }
+                    disabled={ submitStatus === 'SUBMITTING' }
+                    onChange={ e => handleChange(e) }
+                    error={ validations.password != null }
+                    helperText={ validations.password }
+                />
+                <FormControlLabel
+                    control={<Checkbox value="remember" color="primary" disabled={ submitStatus === 'SUBMITTING' }/>}
+                    label="Remember me"
+                />
+                <Button
+                    className={ classes.submit }
+                    type='submit'
+                    variant='contained'
+                    color='primary'
+                    fullWidth
+                    disabled={ submitStatus === 'SUBMITTING' }
+                >
+                    { submitStatus === 'SUBMITTING' ? 'Signing In ...' : 'Sign In' }
+                </Button>
+                <Grid container>
+                    <Grid item xs>
+                        <Link href='/forgotPassword' variant='body2'>
+                            Forgot password?
+                        </Link>
+                    </Grid>
+                    <Grid item>
+                        <Link to='/signUp' variant="body2">
+                            Don&apos;t have an account? Sign Up
+                        </Link>
+                    </Grid>
+                </Grid>
+            </form>
+        </div>
+    );
+}
+
+SignIn.propTypes = {
+    values: PropTypes.shape({
+        email: PropTypes.string,
+        password: PropTypes.string
+    }),
+    handleChange: PropTypes.func,
+    handleSubmit: PropTypes.func,
+    validations: PropTypes.shape({
+        email: PropTypes.string,
+        password: PropTypes.string,
+        form: PropTypes.string
+    }),
+    submitStatus: PropTypes.string
+};

--- a/dashboard-ui/src/components/SignIn.js
+++ b/dashboard-ui/src/components/SignIn.js
@@ -67,6 +67,7 @@ export default function SignIn({ values, handleChange, handleSubmit, validations
                     variant='outlined'
                     margin='normal'
                     type='email'
+                    autoComplete='email'
                     fullWidth
                     autoFocus
                     value={values.email}

--- a/dashboard-ui/src/components/Signup.js
+++ b/dashboard-ui/src/components/Signup.js
@@ -1,0 +1,172 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Avatar from '@material-ui/core/Avatar';
+import Button from '@material-ui/core/Button';
+import TextField from '@material-ui/core/TextField';
+import Link from '@material-ui/core/Link';
+import Grid from '@material-ui/core/Grid';
+import LockOutlinedIcon from '@material-ui/icons/LockOutlined';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
+
+import Alert from './Alert';
+
+const useStyles = makeStyles((theme) => ({
+    paper: {
+        display: 'flex',
+        marginTop: theme.spacing(8),
+        flexDirection: 'column',
+        alignItems: 'center'
+    },
+    avatar: {
+        margin: theme.spacing(1),
+        backgroundColor: theme.palette.secondary.main
+    },
+    form: {
+        width: '100%',
+        marginTop: theme.spacing(1)
+    },
+    submit: {
+        margin: theme.spacing(3, 0, 2)
+    },
+    validations: {
+        width: '100%'
+    }
+}));
+
+export default function Signup({ values, handleChange, handleSubmit, validations, submitStatus }) {
+    const classes = useStyles();
+    return (
+        <div className={ classes.paper }>
+            <Avatar  className={ classes.avatar }>
+                <LockOutlinedIcon />
+            </Avatar>
+            <Typography component='h1' variant='h5'>
+                Sign Up
+            </Typography>
+            <div className={ classes.validations }>
+                { submitStatus === 'SUBMITTED' && <Alert severity='success' text='Account created successfully!' /> }
+                { validations.form != null && <Alert severity='error' text={validations.form} /> }
+            </div>
+            <form className={ classes.form } onSubmit={ handleSubmit } noValidate>
+                <Grid container spacing={2}>
+                    <Grid item xs={12} sm={6}>
+                        <TextField
+                            name='firstName'
+                            required
+                            id='firstName'
+                            label='First Name'
+                            variant='outlined'
+                            autoFocus
+                            fullWidth
+                            value={ values.firstName }
+                            disabled={ submitStatus === 'SUBMITTING' }
+                            onChange={ e => handleChange(e) }
+                            error={ validations.firstName != null }
+                            helperText={ validations.firstName }
+                        />
+                    </Grid>
+                    <Grid item xs={12} sm={6}>
+                        <TextField
+                            name='lastName'
+                            required
+                            id='lastName'
+                            label='Last Name'
+                            variant='outlined'
+                            fullWidth
+                            value={ values.lastName }
+                            disabled={ submitStatus === 'SUBMITTING' }
+                            onChange={ e => handleChange(e) }
+                            error={ validations.lastName != null }
+                            helperText={ validations.lastName }
+                        />
+                    </Grid>
+                    <Grid item xs={12} sm={12}>
+                        <TextField
+                            name='email'
+                            required
+                            id='email'
+                            label='Email Address'
+                            variant='outlined'
+                            fullWidth
+                            value={ values.email }
+                            disabled={ submitStatus === 'SUBMITTING' }
+                            onChange={ e => handleChange(e) }
+                            error={ validations.email != null }
+                            helperText={ validations.email }
+                        />
+                    </Grid>
+                    <Grid item xs={12} sm={12}>
+                        <TextField
+                            name='newPassword'
+                            required
+                            id='pasnewPasswordsword'
+                            label='New Password'
+                            variant='outlined'
+                            fullWidth
+                            value={ values.newPassword }
+                            disabled={ submitStatus === 'SUBMITTING' }
+                            onChange={ e => handleChange(e) }
+                            error={ validations.newPassword != null }
+                            helperText={ validations.newPassword }
+                        />
+                    </Grid>
+                    <Grid item xs={12} sm={12}>
+                        <TextField
+                            name='confirmedPassword'
+                            required
+                            id='confirmedPassword'
+                            label='Confirm Password'
+                            variant='outlined'
+                            fullWidth
+                            value={ values.confirmedPassword }
+                            disabled={ submitStatus === 'SUBMITTING' }
+                            onChange={ e => handleChange(e) }
+                            error={ validations.confirmedPassword != null }
+                            helperText={ validations.confirmedPassword }
+                        />
+                    </Grid>
+                </Grid>
+                <Button
+                    className={ classes.submit }
+                    type='submit'
+                    variant='contained'
+                    color='primary'
+                    fullWidth
+                    disabled={ submitStatus === 'SUBMITTING' }
+                >
+                    { submitStatus === 'SUBMITTING' ? 'Signing Up ...' : 'Sign Up' }
+                </Button>
+                <Grid container justify='flex-end'>
+                    <Grid item>
+                        <Link to='/signIn' variant='body2'>
+                            Already have an account? Sign In
+                        </Link>
+                    </Grid>
+                </Grid>
+            </form>
+        </div>
+    );
+}
+
+Signup.propTypes = {
+    values: PropTypes.shape({
+        email: PropTypes.string,
+        firstName: PropTypes.string,
+        lastName: PropTypes.string,
+        newPassword: PropTypes.string,
+        confirmedPassword: PropTypes.string
+    }),
+    handleChange: PropTypes.func,
+    handleSubmit: PropTypes.func,
+    validations: PropTypes.shape({
+        email: PropTypes.string,
+        firstName: PropTypes.string,
+        lastName: PropTypes.string,
+        newPassword: PropTypes.string,
+        confirmedPassword: PropTypes.string,
+        form: PropTypes.string
+    }),
+    submitStatus: PropTypes.string
+};

--- a/dashboard-ui/src/components/Signup.js
+++ b/dashboard-ui/src/components/Signup.js
@@ -93,6 +93,7 @@ export default function Signup({ values, handleChange, handleSubmit, validations
                             type='email'
                             fullWidth
                             value={values.email}
+                            autoComplete='email'
                             disabled={submitStatus === 'SUBMITTING'}
                             onChange={e => handleChange(e)}
                             error={validations.email != null}
@@ -109,6 +110,7 @@ export default function Signup({ values, handleChange, handleSubmit, validations
                             type='password'
                             fullWidth
                             value={values.newPassword}
+                            autoComplete='new-password'
                             disabled={submitStatus === 'SUBMITTING'}
                             onChange={e => handleChange(e)}
                             error={validations.newPassword != null}
@@ -125,6 +127,7 @@ export default function Signup({ values, handleChange, handleSubmit, validations
                             type='password'
                             fullWidth
                             value={values.confirmedPassword}
+                            autoComplete='new-password'
                             disabled={submitStatus === 'SUBMITTING'}
                             onChange={e => handleChange(e)}
                             error={validations.confirmedPassword != null}

--- a/dashboard-ui/src/components/Signup.js
+++ b/dashboard-ui/src/components/Signup.js
@@ -59,6 +59,7 @@ export default function Signup({ values, handleChange, handleSubmit, validations
                             id='firstName'
                             label='First Name'
                             variant='outlined'
+                            style={{ marginTop: '8px'}}
                             autoFocus
                             fullWidth
                             value={values.firstName}
@@ -75,6 +76,7 @@ export default function Signup({ values, handleChange, handleSubmit, validations
                             id='lastName'
                             label='Last Name'
                             variant='outlined'
+                            style={{ marginTop: '8px'}}
                             fullWidth
                             value={values.lastName}
                             disabled={submitStatus === 'SUBMITTING'}

--- a/dashboard-ui/src/components/Signup.js
+++ b/dashboard-ui/src/components/Signup.js
@@ -18,7 +18,13 @@ const useStyles = makeStyles((theme) => ({
         display: 'flex',
         marginTop: theme.spacing(8),
         flexDirection: 'column',
-        alignItems: 'center'
+        alignItems: 'center',
+        width: '50%',
+        borderColor: theme.palette.divider,
+        borderStyle: 'solid',
+        borderWidth: '1px',
+        borderRadius: '5px',
+        padding: theme.spacing(3, 2)
     },
     avatar: {
         margin: theme.spacing(1),

--- a/dashboard-ui/src/components/Signup.js
+++ b/dashboard-ui/src/components/Signup.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link as RouterLink } from 'react-router-dom';
 
 import Avatar from '@material-ui/core/Avatar';
 import Button from '@material-ui/core/Button';
@@ -38,18 +39,18 @@ const useStyles = makeStyles((theme) => ({
 export default function Signup({ values, handleChange, handleSubmit, validations, submitStatus }) {
     const classes = useStyles();
     return (
-        <div className={ classes.paper }>
-            <Avatar  className={ classes.avatar }>
+        <div className={classes.paper}>
+            <Avatar className={classes.avatar}>
                 <LockOutlinedIcon />
             </Avatar>
             <Typography component='h1' variant='h5'>
                 Sign Up
             </Typography>
-            <div className={ classes.validations }>
-                { submitStatus === 'SUBMITTED' && <Alert severity='success' text='Account created successfully!' /> }
-                { validations.form != null && <Alert severity='error' text={validations.form} /> }
+            <div className={classes.validations}>
+                {submitStatus === 'SUBMITTED' && <Alert severity='success' text='Account created successfully!' />}
+                {validations.form != null && <Alert severity='error' text={validations.form} />}
             </div>
-            <form className={ classes.form } onSubmit={ handleSubmit } noValidate>
+            <form className={classes.form} onSubmit={handleSubmit} noValidate>
                 <Grid container spacing={2}>
                     <Grid item xs={12} sm={6}>
                         <TextField
@@ -60,11 +61,11 @@ export default function Signup({ values, handleChange, handleSubmit, validations
                             variant='outlined'
                             autoFocus
                             fullWidth
-                            value={ values.firstName }
-                            disabled={ submitStatus === 'SUBMITTING' }
-                            onChange={ e => handleChange(e) }
-                            error={ validations.firstName != null }
-                            helperText={ validations.firstName }
+                            value={values.firstName}
+                            disabled={submitStatus === 'SUBMITTING'}
+                            onChange={e => handleChange(e)}
+                            error={validations.firstName != null}
+                            helperText={validations.firstName}
                         />
                     </Grid>
                     <Grid item xs={12} sm={6}>
@@ -75,11 +76,11 @@ export default function Signup({ values, handleChange, handleSubmit, validations
                             label='Last Name'
                             variant='outlined'
                             fullWidth
-                            value={ values.lastName }
-                            disabled={ submitStatus === 'SUBMITTING' }
-                            onChange={ e => handleChange(e) }
-                            error={ validations.lastName != null }
-                            helperText={ validations.lastName }
+                            value={values.lastName}
+                            disabled={submitStatus === 'SUBMITTING'}
+                            onChange={e => handleChange(e)}
+                            error={validations.lastName != null}
+                            helperText={validations.lastName}
                         />
                     </Grid>
                     <Grid item xs={12} sm={12}>
@@ -89,27 +90,29 @@ export default function Signup({ values, handleChange, handleSubmit, validations
                             id='email'
                             label='Email Address'
                             variant='outlined'
+                            type='email'
                             fullWidth
-                            value={ values.email }
-                            disabled={ submitStatus === 'SUBMITTING' }
-                            onChange={ e => handleChange(e) }
-                            error={ validations.email != null }
-                            helperText={ validations.email }
+                            value={values.email}
+                            disabled={submitStatus === 'SUBMITTING'}
+                            onChange={e => handleChange(e)}
+                            error={validations.email != null}
+                            helperText={validations.email}
                         />
                     </Grid>
                     <Grid item xs={12} sm={12}>
                         <TextField
                             name='newPassword'
                             required
-                            id='pasnewPasswordsword'
+                            id='newPassword'
                             label='New Password'
                             variant='outlined'
+                            type='password'
                             fullWidth
-                            value={ values.newPassword }
-                            disabled={ submitStatus === 'SUBMITTING' }
-                            onChange={ e => handleChange(e) }
-                            error={ validations.newPassword != null }
-                            helperText={ validations.newPassword }
+                            value={values.newPassword}
+                            disabled={submitStatus === 'SUBMITTING'}
+                            onChange={e => handleChange(e)}
+                            error={validations.newPassword != null}
+                            helperText={validations.newPassword}
                         />
                     </Grid>
                     <Grid item xs={12} sm={12}>
@@ -119,28 +122,29 @@ export default function Signup({ values, handleChange, handleSubmit, validations
                             id='confirmedPassword'
                             label='Confirm Password'
                             variant='outlined'
+                            type='password'
                             fullWidth
-                            value={ values.confirmedPassword }
-                            disabled={ submitStatus === 'SUBMITTING' }
-                            onChange={ e => handleChange(e) }
-                            error={ validations.confirmedPassword != null }
-                            helperText={ validations.confirmedPassword }
+                            value={values.confirmedPassword}
+                            disabled={submitStatus === 'SUBMITTING'}
+                            onChange={e => handleChange(e)}
+                            error={validations.confirmedPassword != null}
+                            helperText={validations.confirmedPassword}
                         />
                     </Grid>
                 </Grid>
                 <Button
-                    className={ classes.submit }
+                    className={classes.submit}
                     type='submit'
                     variant='contained'
                     color='primary'
                     fullWidth
-                    disabled={ submitStatus === 'SUBMITTING' }
+                    disabled={submitStatus === 'SUBMITTING'}
                 >
-                    { submitStatus === 'SUBMITTING' ? 'Signing Up ...' : 'Sign Up' }
+                    {submitStatus === 'SUBMITTING' ? 'Signing Up ...' : 'Sign Up'}
                 </Button>
                 <Grid container justify='flex-end'>
                     <Grid item>
-                        <Link to='/signIn' variant='body2'>
+                        <Link to='/' component={RouterLink} variant='body2'>
                             Already have an account? Sign In
                         </Link>
                     </Grid>

--- a/dashboard-ui/src/context/authProvider.js
+++ b/dashboard-ui/src/context/authProvider.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const AuthContext = React.createContext();
+
+function AuthContextProvider({ children }) {
+    const [currentUser, setCurrentUser] = React.useState();
+
+    const value = {
+        currentUser
+    };
+
+    return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+AuthContext.propTypes = {
+    children: PropTypes.node
+};
+
+function useUserAuth() {
+    const userAuth = React.useContext(AuthContext);
+
+    if (userAuth === undefined) {
+        throw new Error('useUserAuth must be used inside AuthContextProvider');
+    }
+
+    return userAuth;
+}
+
+export { useUserAuth, AuthContextProvider };

--- a/dashboard-ui/src/context/authProvider.js
+++ b/dashboard-ui/src/context/authProvider.js
@@ -4,27 +4,37 @@ import PropTypes from 'prop-types';
 const AuthContext = React.createContext();
 
 function AuthContextProvider({ children }) {
-    const [currentUser, setCurrentUser] = React.useState();
+    const existingAuthToken = localStorage.getItem('auth-token');
+    const [authToken, setAuthToken] = React.useState(existingAuthToken);
 
     const value = {
-        currentUser
+        authToken,
+        setAuthToken
     };
 
-    return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+    return (
+        <AuthContext.Provider value={value}>
+            {children}
+        </AuthContext.Provider>
+    );
 }
 
 AuthContextProvider.propTypes = {
     children: PropTypes.node
 };
 
+/**
+ * wrapper method over useContext to handle undefined values
+ * @returns a valid value that is stored in the context
+ */
 function useUserAuth() {
-    const userAuth = React.useContext(AuthContext);
+    const userAuthContext = React.useContext(AuthContext);
 
-    if (userAuth === undefined) {
+    if (userAuthContext === undefined) {
         throw new Error('useUserAuth must be used inside AuthContextProvider');
     }
 
-    return userAuth;
+    return userAuthContext;
 }
 
 export { useUserAuth, AuthContextProvider };

--- a/dashboard-ui/src/context/authProvider.js
+++ b/dashboard-ui/src/context/authProvider.js
@@ -13,7 +13,7 @@ function AuthContextProvider({ children }) {
     return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 
-AuthContext.propTypes = {
+AuthContextProvider.propTypes = {
     children: PropTypes.node
 };
 

--- a/dashboard-ui/src/context/authProvider.js
+++ b/dashboard-ui/src/context/authProvider.js
@@ -1,5 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import faker from 'faker';
+
+import { authenticateUser, createUser } from '../clients/DashboardClient';
 
 const AuthContext = React.createContext();
 
@@ -7,9 +10,49 @@ function AuthContextProvider({ children }) {
     const existingAuthToken = localStorage.getItem('auth-token');
     const [authToken, setAuthToken] = React.useState(existingAuthToken);
 
+    const login = async ({ email, password }, setAuthToken) => {
+        let authToken;
+        let errorMessage = null;
+        try {
+            authToken = await authenticateUser({ username: email, password });
+        } catch (err) {
+            errorMessage = `${err.message}. Please create an account first.`;
+        }
+
+        console.info('Persisting auth token in localStorage and Context: ' + authToken);
+
+        // persist the token to localStorage and in context provider via state setter
+        // TODO: figure out if we need to invalidate the `user` react-query
+        localStorage.setItem('auth-token', authToken);
+        setAuthToken(authToken);
+
+        return errorMessage;
+    };
+
+    const createAccount = async newUserDetails => {
+        const newUserData = {
+            firstName: newUserDetails.firstName,
+            lastName: newUserDetails.lastName,
+            email: newUserDetails.email,
+            password: newUserDetails.newPassword,
+            authToken: faker.random.uuid()
+        };
+
+        let errorMessage = null;
+        try {
+            await createUser(newUserData);
+        } catch (err) {
+            errorMessage = `${err.message}. Try logging in instead.`;
+        }
+
+        return errorMessage;
+    };
+
     const value = {
         authToken,
-        setAuthToken
+        setAuthToken,
+        login,
+        createAccount
     };
 
     return (

--- a/dashboard-ui/src/context/authProvider.js
+++ b/dashboard-ui/src/context/authProvider.js
@@ -19,12 +19,14 @@ function AuthContextProvider({ children }) {
             errorMessage = `${err.message}. Please create an account first.`;
         }
 
-        console.info('Persisting auth token in localStorage and Context: ' + authToken);
+        if (errorMessage == null) {
+            console.info('Persisting auth token in localStorage and Context: ' + authToken);
 
-        // persist the token to localStorage and in context provider via state setter
-        // TODO: figure out if we need to invalidate the `user` react-query
-        localStorage.setItem('auth-token', authToken);
-        setAuthToken(authToken);
+            // persist the token to localStorage and in context provider via state setter
+            // TODO: figure out if we need to invalidate the `user` react-query
+            localStorage.setItem('auth-token', authToken);
+            setAuthToken(authToken);
+        }
 
         return errorMessage;
     };

--- a/dashboard-ui/src/context/authProvider.js
+++ b/dashboard-ui/src/context/authProvider.js
@@ -1,18 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import faker from 'faker';
+import { useQueryClient } from 'react-query';
 
 import { authenticateUser, createUser } from '../clients/DashboardClient';
+import { queryKeys } from '../utils';
 
 const AuthContext = React.createContext();
 
 function AuthContextProvider({ children }) {
     const existingAuthToken = localStorage.getItem('auth-token');
     const [authToken, setAuthToken] = React.useState(existingAuthToken);
+    const queryClient = useQueryClient();
 
     const login = async ({ email, password }, setAuthToken) => {
         let authToken;
         let errorMessage = null;
+
         try {
             authToken = await authenticateUser({ username: email, password });
         } catch (err) {
@@ -23,8 +27,8 @@ function AuthContextProvider({ children }) {
             console.info('Persisting auth token in localStorage and Context: ' + authToken);
 
             // persist the token to localStorage and in context provider via state setter
-            // TODO: figure out if we need to invalidate the `user` react-query
             localStorage.setItem('auth-token', authToken);
+            queryClient.invalidateQueries(queryKeys.USER_DATA);
             setAuthToken(authToken);
         }
 

--- a/dashboard-ui/src/context/authProvider.js
+++ b/dashboard-ui/src/context/authProvider.js
@@ -48,11 +48,18 @@ function AuthContextProvider({ children }) {
         return errorMessage;
     };
 
+    const logOut = () => {
+        console.info('Logging user out ...');
+        localStorage.removeItem('auth-token');
+        setAuthToken(null);
+    };
+
     const value = {
         authToken,
         setAuthToken,
         login,
-        createAccount
+        createAccount,
+        logOut
     };
 
     return (

--- a/dashboard-ui/src/hooks/useForm.js
+++ b/dashboard-ui/src/hooks/useForm.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { capitalizeLabel } from '../utils';
 import { useUserAuth } from '../context/authProvider';
 
-const validateEmail = email => { return /\S+@\S+\.\S+/.test(email); };
+const validateEmail = email => /\S+@\S+\.\S+/.test(email);
 
 const validateFormData = formData => {
     let validations = {};
@@ -18,11 +18,11 @@ const validateFormData = formData => {
             errorMessage = 'Email is in incorrect format!';
         } else if (key === 'newPassword') {
             newPassword = value;
-            if (value.length < 6 || value.length >= 12) {
+            if (value.length < 6 || value.length > 12) {
                 errorMessage = 'Password must be between 6 and 12 characters!';
             }
         } else if (key === 'confirmedPassword') {
-            if (value.length < 6 || value.length >= 12) {
+            if (value.length < 6 || value.length > 12) {
                 errorMessage = 'Password must be between 6 and 12 characters!';
             } else if (value !== newPassword) {
                 errorMessage = 'Passwords must match!';

--- a/dashboard-ui/src/hooks/useForm.js
+++ b/dashboard-ui/src/hooks/useForm.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { authenticateUser } from '../clients/DashboardClient';
 
 import { capitalizeLabel } from '../utils';
+import { useUserAuth } from '../context/authProvider';
 
 const validateEmail = email => { return /\S+@\S+\.\S+/.test(email); };
 
@@ -41,18 +41,8 @@ const validateFormData = formData => {
     };
 };
 
-const login = async ({email, password}, setAuthToken) => {
-    const authToken = await authenticateUser({ username: email, password });
-
-    console.info('Persisting auth token in localStorage and Context: ' + authToken);
-
-    // persist the token to localStorage and in context provider via state setter
-    // TODO: figure out if we need to invalidate the `user` react-query
-    localStorage.setItem('auth-token', authToken);
-    setAuthToken(authToken);
-};
-
-const useForm = setAuthToken => {
+const useForm = () => {
+    const { setAuthToken, login, createAccount } = useUserAuth();
     const [submitStatus, setSubmitStatus] = React.useState();
 
     // sign in form data

--- a/dashboard-ui/src/hooks/useForm.js
+++ b/dashboard-ui/src/hooks/useForm.js
@@ -1,0 +1,125 @@
+import React from 'react';
+
+import { capitalizeLabel } from '../utils';
+
+const validateEmail = email => { return /\S+@\S+\.\S+/.test(email); };
+
+const validateFormData = formData => {
+    let validations = {};
+
+    let newPassword;
+    Object.entries(formData).forEach(([key, value]) => {
+        let errorMessage = null;
+
+        if (!value.trim()) {
+            errorMessage = `${capitalizeLabel(key)} cannot be empty!`;
+        } else if (key === 'email' && !validateEmail(value)) {
+            errorMessage = 'Email is in incorrect format!';
+        } else if (key === 'newPassword') {
+            newPassword = value;
+            if (value.length < 6 || value.length >= 12) {
+                errorMessage = 'Password must be between 6 and 12 characters!';
+            }
+        } else if (key === 'confirmedPassword') {
+            if (value.length < 6 || value.length >= 12) {
+                errorMessage = 'Password must be between 6 and 12 characters!';
+            } else if (value != newPassword) {
+                errorMessage = 'Passwords must match!';
+            }
+        }
+
+        validations = {
+            ...validations,
+            [key]: errorMessage
+        };
+    });
+
+    return {
+        ...validations,
+        form: null
+    };
+};
+
+const useForm = () => {
+    const [submitStatus, setSubmitStatus] = React.useState();
+
+    // sign in form data
+    const [signInFormData, setSignInFormData] = React.useState({
+        email: '',
+        password: ''
+    });
+
+    const [signInFormValidations, setSignInFormValidations] = React.useState({
+        email: null,
+        password: null,
+        form: null
+    });
+
+    // sign up form data
+    const [signUpFormData, setSignUpFormData] = React.useState({
+        firstName: '',
+        lastName: '',
+        email: '',
+        newPassword: '',
+        confirmedPassword: ''
+    });
+
+    const [signUpFormValidations, setSignUpFormValidations] = React.useState({
+        firstName: null,
+        lastName: null,
+        email: null,
+        newPassword: null,
+        confirmedPassword: null,
+        form: null
+    });
+
+    // common logic
+    const handleSubmitFn = (e, formData, setFormValidations) => {
+        e.preventDefault();
+
+        setFormValidations(validateFormData(formData));
+
+        // lock form by disabling input fields and button
+        setSubmitStatus('SUBMITTING');
+    };
+
+    const handleChangeFn = (e, formData, setFormData) => {
+        const { name, value } = e.target;
+        setFormData({
+            ...formData,
+            [name]: value
+        });
+    };
+
+    const submitFormLogic = formValidations => {
+        if (submitStatus === 'SUBMITTING' && Object.values(formValidations).every(validation => validation == null)) {
+            // TODO: call sign in endpoint here
+            setSubmitStatus('SUBMITTED');
+        } else {
+            // reset/unlock form
+            setSubmitStatus(null);
+        }
+    };
+
+    React.useEffect(() => {
+        submitFormLogic(signInFormValidations);
+    }, [signInFormValidations]);
+
+    React.useEffect(() => {
+        submitFormLogic(signUpFormValidations);
+    }, [signUpFormValidations]);
+
+    return {
+        submitStatus,
+        signInFormData,
+        signInFormValidations,
+        signInFormChangeHandler: e => handleChangeFn(e, signInFormData, setSignInFormData),
+        signInFormSubmitHandler: e => handleSubmitFn(e, signInFormData, setSignInFormValidations),
+        signUpFormData,
+        signUpFormValidations,
+        signUpFormChangeHandler: e => handleChangeFn(e, signUpFormData, setSignUpFormData),
+        signUpFormSubmitHandler: e => handleSubmitFn(e, signUpFormData, setSignUpFormValidations)
+    };
+};
+
+export default useForm;

--- a/dashboard-ui/src/hooks/useForm.js
+++ b/dashboard-ui/src/hooks/useForm.js
@@ -93,22 +93,28 @@ const useForm = () => {
         });
     };
 
-    const submitFormLogic = (formValidations, authAction) => {
+    async function submitFormLogic(formValidations, setFormValidations, authAction) {
         if (submitStatus === 'SUBMITTING' && Object.values(formValidations).every(validation => validation == null)) {
-            authAction();
+            const formErrorMessage = await authAction();
+            if (formErrorMessage != null) {
+                setFormValidations({
+                    ...formValidations,
+                    form: formErrorMessage
+                });
+            }
             setSubmitStatus('SUBMITTED');
         } else {
             // reset/unlock form
             setSubmitStatus(null);
         }
-    };
+    }
 
     React.useEffect(() => {
-        submitFormLogic(signInFormValidations, () => login(signInFormData, setAuthToken));
+        submitFormLogic(signInFormValidations, setSignInFormValidations, () => login(signInFormData, setAuthToken));
     }, [signInFormValidations]);
 
     React.useEffect(() => {
-        submitFormLogic(signUpFormValidations);
+        submitFormLogic(signUpFormValidations, setSignUpFormValidations, () => createAccount(signUpFormData));
     }, [signUpFormValidations]);
 
     return {

--- a/dashboard-ui/src/hooks/useUserData.js
+++ b/dashboard-ui/src/hooks/useUserData.js
@@ -1,0 +1,19 @@
+import { useQuery } from 'react-query';
+import { fetchUser } from '../clients/DashboardClient';
+import { queryKeys } from '../utils';
+
+export default function(authToken) {
+    const { isLoading, isSuccess, data } = useQuery(
+        [queryKeys.USER_DATA, { authToken }],
+        fetchUser, {
+            retry: 0,
+            staleTime: 1000 * 60 * 60 * 8,
+            onError: (err) => console.log(err)
+        }
+    );
+    return {
+        isLoading,
+        isLoggedIn: isSuccess && data,
+        userData: isLoading || !isSuccess ? null : data
+    };
+}

--- a/dashboard-ui/src/hooks/useUserData.js
+++ b/dashboard-ui/src/hooks/useUserData.js
@@ -8,7 +8,6 @@ export default function(authToken) {
         fetchUser, {
             retry: 0,
             staleTime: 1000 * 60 * 60 * 8,
-            onError: (err) => console.log(err)
         }
     );
     return {

--- a/dashboard-ui/src/pages/UserAuth.js
+++ b/dashboard-ui/src/pages/UserAuth.js
@@ -22,6 +22,10 @@ export default function UserAuth({ classes }) {
     );
 }
 
+UserAuth.propTypes = {
+    classes: PropTypes.node
+};
+
 const SignInContainer = () => {
     const {
         signInFormData,

--- a/dashboard-ui/src/pages/UserAuth.js
+++ b/dashboard-ui/src/pages/UserAuth.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Route, Switch } from 'react-router-dom';
+import PropTypes from 'prop-types';
+
+import SignIn from '../components/SignIn';
+import SignUp from '../components/Signup';
+
+import useForm from '../hooks/useForm';
+
+export default function UserAuth({ classes }) {
+    return (
+        <div className={classes.content}>
+            <Switch>
+                <Route exact path='/'>
+                    <SignInContainer />
+                </Route>
+                <Route path='/signUp'>
+                    <SignUpContainer />
+                </Route>
+            </Switch>
+        </div>
+    );
+}
+
+const SignInContainer = () => {
+    const {
+        signInFormData,
+        submitStatus,
+        signInFormValidations,
+        signInFormChangeHandler: handleChangeFn,
+        signInFormSubmitHandler: handleSubmitFn
+    } = useForm();
+    return (
+        <SignIn
+            values={signInFormData}
+            validations={signInFormValidations}
+            handleSubmit={handleSubmitFn}
+            handleChange={handleChangeFn}
+            submitStatus={submitStatus}
+        />
+    );
+};
+
+const SignUpContainer = () => {
+    const {
+        submitStatus,
+        signUpFormData,
+        signUpFormValidations,
+        signUpFormChangeHandler: handleChangeFn,
+        signUpFormSubmitHandler: handleSubmitFn
+    } = useForm();
+    return (
+        <SignUp
+            values={signUpFormData}
+            validations={signUpFormValidations}
+            handleSubmit={handleSubmitFn}
+            handleChange={handleChangeFn}
+            submitStatus={submitStatus}
+        />
+    );
+};

--- a/dashboard-ui/src/pages/UserAuth.js
+++ b/dashboard-ui/src/pages/UserAuth.js
@@ -6,6 +6,7 @@ import SignIn from '../components/SignIn';
 import SignUp from '../components/Signup';
 
 import useForm from '../hooks/useForm';
+import { useUserAuth } from '../context/authProvider';
 
 export default function UserAuth({ classes }) {
     return (
@@ -23,17 +24,19 @@ export default function UserAuth({ classes }) {
 }
 
 UserAuth.propTypes = {
-    classes: PropTypes.node
+    classes: PropTypes.object
 };
 
 const SignInContainer = () => {
+    const { setAuthToken } = useUserAuth();
     const {
         signInFormData,
         submitStatus,
         signInFormValidations,
         signInFormChangeHandler: handleChangeFn,
         signInFormSubmitHandler: handleSubmitFn
-    } = useForm();
+    } = useForm(setAuthToken);
+
     return (
         <SignIn
             values={signInFormData}

--- a/dashboard-ui/src/pages/UserAuth.js
+++ b/dashboard-ui/src/pages/UserAuth.js
@@ -10,14 +10,16 @@ import useForm from '../hooks/useForm';
 export default function UserAuth({ classes }) {
     return (
         <div className={classes.content}>
-            <Switch>
-                <Route exact path='/'>
-                    <SignInContainer />
-                </Route>
-                <Route path='/signUp'>
-                    <SignUpContainer />
-                </Route>
-            </Switch>
+            <div className={classes.formContainer}>
+                <Switch>
+                    <Route exact path='/'>
+                        <SignInContainer />
+                    </Route>
+                    <Route path='/signUp'>
+                        <SignUpContainer />
+                    </Route>
+                </Switch>
+            </div>
         </div>
     );
 }

--- a/dashboard-ui/src/pages/UserAuth.js
+++ b/dashboard-ui/src/pages/UserAuth.js
@@ -6,7 +6,6 @@ import SignIn from '../components/SignIn';
 import SignUp from '../components/Signup';
 
 import useForm from '../hooks/useForm';
-import { useUserAuth } from '../context/authProvider';
 
 export default function UserAuth({ classes }) {
     return (
@@ -28,14 +27,13 @@ UserAuth.propTypes = {
 };
 
 const SignInContainer = () => {
-    const { setAuthToken } = useUserAuth();
     const {
         signInFormData,
         submitStatus,
         signInFormValidations,
         signInFormChangeHandler: handleChangeFn,
         signInFormSubmitHandler: handleSubmitFn
-    } = useForm(setAuthToken);
+    } = useForm();
 
     return (
         <SignIn

--- a/dashboard-ui/src/routingData.js
+++ b/dashboard-ui/src/routingData.js
@@ -7,7 +7,7 @@ import SquadHub from './pages/SquadHub';
 import Home from './pages/Home';
 import Player from './pages/Player';
 
-const sideBarData = [{
+const routingData = [{
     text: 'Home',
     icon: <HomeIcon />,
     routePath: '/',
@@ -29,5 +29,5 @@ const sideBarData = [{
 }];
 
 // TODO: rename to routingData
-export default sideBarData;
+export default routingData;
 

--- a/dashboard-ui/src/routingData.js
+++ b/dashboard-ui/src/routingData.js
@@ -28,6 +28,5 @@ const routingData = [{
     showInSidebar: false
 }];
 
-// TODO: rename to routingData
 export default routingData;
 

--- a/dashboard-ui/src/routingData.js
+++ b/dashboard-ui/src/routingData.js
@@ -28,5 +28,6 @@ const sideBarData = [{
     showInSidebar: false
 }];
 
+// TODO: rename to routingData
 export default sideBarData;
 

--- a/dashboard-ui/src/stories/Alert.stories.js
+++ b/dashboard-ui/src/stories/Alert.stories.js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import Alert from '../components/Alert';
+
+export default {
+    component: Alert,
+    title: 'Components/Globals/Alert'
+};
+
+const Template = args => <Alert { ...args } />;
+
+export const Success = Template.bind({});
+Success.args = {
+    severity: 'success',
+    text: 'This is a success message!'
+};
+
+export const Error = Template.bind({});
+Error.args = {
+    severity: 'error',
+    text: 'This is an error message!'
+};

--- a/dashboard-ui/src/stories/AppBarMenu.stories.js
+++ b/dashboard-ui/src/stories/AppBarMenu.stories.js
@@ -3,7 +3,6 @@ import { action } from '@storybook/addon-actions';
 
 import AppBarMenu from '../components/AppBarMenu';
 
-// TODO: add storybook controls to dynamically change the isOpen prop
 const menuData = {
     menu: {
         title: 'Manchester United',

--- a/dashboard-ui/src/stories/SignIn.stories.js
+++ b/dashboard-ui/src/stories/SignIn.stories.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import SignIn from '../components/SignIn';
+import { mockHandleChange, mockSubmit } from './utils/storyMocks';
+
+export default {
+    component: SignIn,
+    title: 'Components/UserAuth/SignIn'
+};
+
+const defaultArgs = {
+    values: { email: '', password: '' },
+    handleChange: mockHandleChange,
+    handleSubmit: mockSubmit,
+    validations: { email: null, password: null, form: null },
+    submitStatus: null
+};
+const Template = args => <SignIn { ...args }/>;
+
+export const Default = Template.bind({});
+Default.args = defaultArgs;
+
+export const Submitting = Template.bind({});
+Submitting.args = {
+    ...defaultArgs,
+    values: { email: 'fake@test.email', password: 'fakepassword'},
+    submitStatus: 'SUBMITTING'
+};
+
+export const Submitted = Template.bind({});
+Submitted.args = {
+    ...defaultArgs,
+    submitStatus: 'SUBMITTED'
+};
+
+export const FailedInput = Template.bind({});
+FailedInput.args = {
+    ...defaultArgs,
+    validations: {
+        ...defaultArgs.validations,
+        email: 'Email address is not in correct format!',
+        password: 'Password is required'
+    }
+};
+
+export const FailedSubmit = Template.bind({});
+FailedSubmit.args = {
+    ...defaultArgs,
+    validations: { ...defaultArgs.validations, form: 'Email/Password does not match' }
+};

--- a/dashboard-ui/src/stories/SignUp.stories.js
+++ b/dashboard-ui/src/stories/SignUp.stories.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import Signup from '../components/Signup';
+import { mockHandleChange, mockSubmit } from './utils/storyMocks';
+
+export default {
+    component: Signup,
+    title: 'Components/UserAuth/Signup',
+};
+
+const defaultArgs = {
+    values: { firstName: '', lastName: '', email: '', newPassword: '', confirmedPassword: '' },
+    handleChange: mockHandleChange,
+    handleSubmit: mockSubmit,
+    validations: { firstName: null, lastName: null, email: null, newPassword: null, confirmedPassword: null },
+    submitStatus: null
+};
+
+const Template = args => <Signup { ...args }/>;
+export const Default = Template.bind({});
+Default.args = defaultArgs;
+
+export const Submitting = Template.bind({});
+Submitting.args = {
+    ...defaultArgs,
+    values: {
+        firstName: 'fake first name',
+        lastName: 'fake last name',
+        email: 'fake@test.email',
+        newPassword: 'fake new password',
+        confirmedPassword: 'fake confirmed password'
+    },
+    submitStatus: 'SUBMITTING',
+};
+
+export const Submitted = Template.bind({});
+Submitted.args = {
+    ...defaultArgs,
+    submitStatus: 'SUBMITTED'
+};
+
+export const FailedInput = Template.bind({});
+FailedInput.args = {
+    ...defaultArgs,
+    validations: {
+        ...defaultArgs.validations,
+        firstName: 'First Name is required!',
+        lastName: 'LastName Name is required!',
+        email: 'Email is required!',
+        newPassword: 'Password is required!',
+        confirmedPassword: 'Passwords do not match!'
+    }
+};
+
+export const FailedSubmit = Template.bind({});
+FailedSubmit.args = {
+    ...defaultArgs,
+    validations: {
+        ...defaultArgs.validations,
+        form: 'Unable to create account!'
+    }
+};

--- a/dashboard-ui/src/stories/utils/storyMocks.js
+++ b/dashboard-ui/src/stories/utils/storyMocks.js
@@ -1,0 +1,11 @@
+import { action } from '@storybook/addon-actions';
+
+export const mockSubmit = (e) => {
+    e.preventDefault();
+    const submitAction = action('Submitted Sign In Form');
+    submitAction(e);
+};
+export const mockHandleChange = (e) => {
+    const handleChangeAction = action('typing ...');
+    handleChangeAction(e.target.value);
+};

--- a/dashboard-ui/src/utils.js
+++ b/dashboard-ui/src/utils.js
@@ -6,7 +6,8 @@ export const queryKeys = {
     SQUAD_DATA: 'squadData',
     PLAYER_DATA: 'playerData',
     COMPARED_PLAYER_DATA: 'comparedPlayerData',
-    PLAYER_PERFORMANCE_DATA: 'playerPerformance'
+    PLAYER_PERFORMANCE_DATA: 'playerPerformance',
+    USER_DATE: 'userData'
 };
 
 // TODO: this will be returned from the service in future; remove this then

--- a/dashboard-ui/src/utils.js
+++ b/dashboard-ui/src/utils.js
@@ -7,7 +7,7 @@ export const queryKeys = {
     PLAYER_DATA: 'playerData',
     COMPARED_PLAYER_DATA: 'comparedPlayerData',
     PLAYER_PERFORMANCE_DATA: 'playerPerformance',
-    USER_DATE: 'userData'
+    USER_DATA: 'userData'
 };
 
 // TODO: this will be returned from the service in future; remove this then


### PR DESCRIPTION
Implemented the following in this PR -
- [x] Add SignIn and SignUp form components.
- [x] Mock server behavior for auth flow via DashboardClient methods and json-server
- [x] Handle auth flows like creating a new account, authenticating a user when logging in, and logging out the user
- [x] Hide main application if there is no authenticated user. Show auth forms instead. 