### PR TITLE
Simplify form hook

### DIFF
--- a/dashboard-ui/src/components/SignIn.js
+++ b/dashboard-ui/src/components/SignIn.js
@@ -97,7 +97,13 @@ export default function SignIn({ values, handleChange, handleSubmit, validations
                 />
                 {/* // TODO: uncomment when Remember Me functionality is ready */}
                 {/* <FormControlLabel
-                    control={<Checkbox value='remember' color='primary' disabled={submitStatus === formSubmission.INPROGRESS} />}
+                    control={
+                        <Checkbox
+                            value='remember'
+                            color='primary'
+                            disabled={submitStatus === formSubmission.INPROGRESS}
+                        />
+                    }
                     label='Remember me'
                 /> */}
                 <Button

--- a/dashboard-ui/src/components/SignIn.js
+++ b/dashboard-ui/src/components/SignIn.js
@@ -14,8 +14,9 @@ import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 
 import Alert from './Alert';
+import { formSubmission } from '../utils';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(theme => ({
     paper: {
         display: 'flex',
         marginTop: theme.spacing(8),
@@ -55,8 +56,10 @@ export default function SignIn({ values, handleChange, handleSubmit, validations
                 Sign In
             </Typography>
             <div className={classes.validations}>
-                {submitStatus === 'SUBMITTED' && <Alert severity='success' text='Signed In Successfully!' />}
-                {validations.form != null && <Alert severity='error' text={validations.form} />}
+                {submitStatus === formSubmission.COMPLETE && (
+                    <Alert severity='success' text='Signed In Successfully!' />
+                )}
+                {validations.form && <Alert severity='error' text={validations.form} />}
             </div>
             <form className={classes.form} onSubmit={handleSubmit} noValidate>
                 <TextField
@@ -71,9 +74,9 @@ export default function SignIn({ values, handleChange, handleSubmit, validations
                     fullWidth
                     autoFocus
                     value={values.email}
-                    disabled={submitStatus === 'SUBMITTING'}
+                    disabled={submitStatus === formSubmission.INPROGRESS}
                     onChange={e => handleChange(e)}
-                    error={validations.email != null}
+                    error={validations.email}
                     helperText={validations.email}
                 />
                 <TextField
@@ -87,14 +90,14 @@ export default function SignIn({ values, handleChange, handleSubmit, validations
                     fullWidth
                     autoComplete='current-password'
                     value={values.password}
-                    disabled={submitStatus === 'SUBMITTING'}
+                    disabled={submitStatus === formSubmission.INPROGRESS}
                     onChange={e => handleChange(e)}
-                    error={validations.password != null}
+                    error={validations.password}
                     helperText={validations.password}
                 />
                 {/* // TODO: uncomment when Remember Me functionality is ready */}
                 {/* <FormControlLabel
-                    control={<Checkbox value='remember' color='primary' disabled={submitStatus === 'SUBMITTING'} />}
+                    control={<Checkbox value='remember' color='primary' disabled={submitStatus === formSubmission.INPROGRESS} />}
                     label='Remember me'
                 /> */}
                 <Button
@@ -103,9 +106,9 @@ export default function SignIn({ values, handleChange, handleSubmit, validations
                     variant='contained'
                     color='primary'
                     fullWidth
-                    disabled={submitStatus === 'SUBMITTING'}
+                    disabled={submitStatus === formSubmission.INPROGRESS}
                 >
-                    {submitStatus === 'SUBMITTING' ? 'Signing In ...' : 'Sign In'}
+                    {submitStatus === formSubmission.INPROGRESS ? 'Signing In ...' : 'Sign In'}
                 </Button>
                 <Grid container>
                     {/* // TODO: uncomment when forgot password functionality is ready */}

--- a/dashboard-ui/src/components/Signup.js
+++ b/dashboard-ui/src/components/Signup.js
@@ -12,8 +12,9 @@ import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 
 import Alert from './Alert';
+import { formSubmission } from '../utils';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(theme => ({
     paper: {
         display: 'flex',
         marginTop: theme.spacing(8),
@@ -53,7 +54,9 @@ export default function Signup({ values, handleChange, handleSubmit, validations
                 Sign Up
             </Typography>
             <div className={classes.validations}>
-                {submitStatus === 'SUBMITTED' && <Alert severity='success' text='Account created successfully!' />}
+                {submitStatus === formSubmission.COMPLETE && (
+                    <Alert severity='success' text='Account created successfully!' />
+                )}
                 {validations.form != null && <Alert severity='error' text={validations.form} />}
             </div>
             <form className={classes.form} onSubmit={handleSubmit} noValidate>
@@ -65,11 +68,11 @@ export default function Signup({ values, handleChange, handleSubmit, validations
                             id='firstName'
                             label='First Name'
                             variant='outlined'
-                            style={{ marginTop: '8px'}}
+                            style={{ marginTop: '8px' }}
                             autoFocus
                             fullWidth
                             value={values.firstName}
-                            disabled={submitStatus === 'SUBMITTING'}
+                            disabled={submitStatus === formSubmission.INPROGRESS}
                             onChange={e => handleChange(e)}
                             error={validations.firstName != null}
                             helperText={validations.firstName}
@@ -82,10 +85,10 @@ export default function Signup({ values, handleChange, handleSubmit, validations
                             id='lastName'
                             label='Last Name'
                             variant='outlined'
-                            style={{ marginTop: '8px'}}
+                            style={{ marginTop: '8px' }}
                             fullWidth
                             value={values.lastName}
-                            disabled={submitStatus === 'SUBMITTING'}
+                            disabled={submitStatus === formSubmission.INPROGRESS}
                             onChange={e => handleChange(e)}
                             error={validations.lastName != null}
                             helperText={validations.lastName}
@@ -102,7 +105,7 @@ export default function Signup({ values, handleChange, handleSubmit, validations
                             fullWidth
                             value={values.email}
                             autoComplete='email'
-                            disabled={submitStatus === 'SUBMITTING'}
+                            disabled={submitStatus === formSubmission.INPROGRESS}
                             onChange={e => handleChange(e)}
                             error={validations.email != null}
                             helperText={validations.email}
@@ -119,7 +122,7 @@ export default function Signup({ values, handleChange, handleSubmit, validations
                             fullWidth
                             value={values.newPassword}
                             autoComplete='new-password'
-                            disabled={submitStatus === 'SUBMITTING'}
+                            disabled={submitStatus === formSubmission.INPROGRESS}
                             onChange={e => handleChange(e)}
                             error={validations.newPassword != null}
                             helperText={validations.newPassword}
@@ -136,7 +139,7 @@ export default function Signup({ values, handleChange, handleSubmit, validations
                             fullWidth
                             value={values.confirmedPassword}
                             autoComplete='new-password'
-                            disabled={submitStatus === 'SUBMITTING'}
+                            disabled={submitStatus === formSubmission.INPROGRESS}
                             onChange={e => handleChange(e)}
                             error={validations.confirmedPassword != null}
                             helperText={validations.confirmedPassword}
@@ -149,9 +152,9 @@ export default function Signup({ values, handleChange, handleSubmit, validations
                     variant='contained'
                     color='primary'
                     fullWidth
-                    disabled={submitStatus === 'SUBMITTING'}
+                    disabled={submitStatus === formSubmission.INPROGRESS}
                 >
-                    {submitStatus === 'SUBMITTING' ? 'Signing Up ...' : 'Sign Up'}
+                    {submitStatus === formSubmission.INPROGRESS ? 'Signing Up ...' : 'Sign Up'}
                 </Button>
                 <Grid container justify='flex-end'>
                     <Grid item>

--- a/dashboard-ui/src/context/authProvider.js
+++ b/dashboard-ui/src/context/authProvider.js
@@ -48,7 +48,7 @@ function AuthContextProvider({ children }) {
         try {
             await createUser(newUserData);
         } catch (err) {
-            errorMessage = `${err.message}. Try logging in instead.`;
+            errorMessage = `${err.message} Try logging in instead.`;
         }
 
         return errorMessage;

--- a/dashboard-ui/src/pages/UserAuth.js
+++ b/dashboard-ui/src/pages/UserAuth.js
@@ -6,6 +6,7 @@ import SignIn from '../components/SignIn';
 import SignUp from '../components/Signup';
 
 import useForm from '../hooks/useForm';
+import { useUserAuth } from '../context/authProvider';
 
 export default function UserAuth({ classes }) {
     return (
@@ -29,13 +30,20 @@ UserAuth.propTypes = {
 };
 
 const SignInContainer = () => {
+    const { setAuthToken, login } = useUserAuth();
     const {
-        signInFormData,
-        submitStatus,
-        signInFormValidations,
-        signInFormChangeHandler: handleChangeFn,
-        signInFormSubmitHandler: handleSubmitFn
-    } = useForm();
+        handleChangeFn,
+        handleSubmitFn,
+        formData: signInFormData,
+        formValidations: signInFormValidations,
+        submitStatus
+    } = useForm(
+        {
+            email: '',
+            password: ''
+        },
+        React.useCallback(authData => login(authData, setAuthToken), [login, setAuthToken])
+    );
 
     return (
         <SignIn
@@ -49,13 +57,23 @@ const SignInContainer = () => {
 };
 
 const SignUpContainer = () => {
+    const { setAuthToken, createAccount } = useUserAuth();
     const {
-        submitStatus,
-        signUpFormData,
-        signUpFormValidations,
-        signUpFormChangeHandler: handleChangeFn,
-        signUpFormSubmitHandler: handleSubmitFn
-    } = useForm();
+        handleChangeFn,
+        handleSubmitFn,
+        formData: signUpFormData,
+        formValidations: signUpFormValidations,
+        submitStatus
+    } = useForm(
+        {
+            firstName: '',
+            lastName: '',
+            email: '',
+            newPassword: '',
+            confirmedPassword: ''
+        },
+        React.useCallback(userCreds => createAccount(userCreds, setAuthToken), [createAccount, setAuthToken])
+    );
     return (
         <SignUp
             values={signUpFormData}

--- a/dashboard-ui/src/utils.js
+++ b/dashboard-ui/src/utils.js
@@ -57,6 +57,11 @@ export const moraleIconsMap = [
     { morale: 'Happy', icon: <MoodIcon /> }
 ];
 
+export const formSubmission = {
+    COMPLETE: 'COMPLETE',
+    INPROGRESS: 'INPROGRESS'
+};
+
 export const capitalizeLabel = label => {
     return label
         .split('_')


### PR DESCRIPTION
- `useForm` hook was tightly coupled to the signup and sign-in forms. Restructured the entire hook to house only form handling specific logic. Moved business logic specific code to be defined on invocation in the UserAuth class. 
- There were also a lot of imperative coding patterns that I changed to be more functional. 
- Added use of `useCallback` hooks to stabilize some callbacks.