### PR TITLE
Add custom java build steps to codeql workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up cache for ~/.m2/repository
-      uses: actions/cache@2.1.6
+      uses: actions/cache@v2.1.6
       with:
         path: ~/.m2/repository
         key: maven-${{ matrix.os }}-java${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,6 +33,8 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'java', 'javascript' ]
+        os: [ ubuntu-latest ]
+        java: [8, 11]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
@@ -40,6 +42,51 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+
+    - name: Set up cache for ~/.m2/repository
+      uses: actions/cache@2.1.6
+      with:
+        path: ~/.m2/repository
+        key: maven-${{ matrix.os }}-java${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys:
+          maven-${{ matrix.os }}-java${{ matrix.java }}-
+          maven-${{ matrix.os }}-
+
+    - name: Install JDK To Be Used In ToolChain
+      if: ${{ matrix.java == '11' }}
+      uses: battila7/jdk-via-jabba@v1.3.0
+      with:
+        jdk: adopt-openj9@1.11.0-7
+        javaHomeEnvironmentVariable: TOOLCHAIN_JDK
+
+    - name: Set Up Toolchain XML
+      if: ${{ matrix.java == '11' }}
+      shell: bash
+      run: |
+        mkdir -p $HOME/.m2 \
+        && cat << EOF > $HOME/.m2/toolchains.xml
+        <?xml version="1.0" encoding="UTF8"?>
+        <toolchains>
+          <toolchain>
+            <type>jdk</type>
+              <provides>
+                <version>11</version>
+                <vendor>adopt</vendor>
+              </provides>
+              <configuration>
+                <jdkHome>${{ env.TOOLCHAIN_JDK }}</jdkHome>
+              </configuration>
+          </toolchain>
+        </toolchains>
+        EOF
+
+    - name: Set Up JDK
+      uses: actions/setup-java@v2.2.0
+      with:
+        java-version: ${{ matrix.java }}
+
+    - name: Build With Maven
+      run: mvn clean install
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -53,8 +100,8 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+    #- name: Autobuild
+    #  uses: github/codeql-action/autobuild@v1
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -56,7 +56,7 @@ jobs:
       if: ${{ matrix.java == '11' }}
       uses: battila7/jdk-via-jabba@v1.3.0
       with:
-        jdk: adopt-openj9@1.11.0-7
+        jdk: adopt-openj9@1.11.0-11
         javaHomeEnvironmentVariable: TOOLCHAIN_JDK
 
     - name: Set Up Toolchain XML

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -112,7 +112,7 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    - run: cd dashboard-server && mvn clean install
+    - run: cd dashboard-server && mvn clean install -e
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -112,7 +112,9 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    - run: cd dashboard-server && mvn clean install -e
+    - run: |
+        rm -rf ~/.m2/repository/* && \
+        cd dashboard-server && mvn clean install -U -e
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,13 +52,6 @@ jobs:
           maven-${{ matrix.os }}-java${{ matrix.java }}-
           maven-${{ matrix.os }}-
 
-    - name: Install JDK To Be Used In ToolChain
-      if: ${{ matrix.java == '11' }}
-      uses: battila7/jdk-via-jabba@v1.3.0
-      with:
-        jdk: adopt-openj9@11.0.5-1
-        javaHomeEnvironmentVariable: TOOLCHAIN_JDK
-
     - name: Set Up Toolchain XML
       if: ${{ matrix.java == '11' }}
       shell: bash
@@ -74,7 +67,7 @@ jobs:
                 <vendor>adoptopenjdk</vendor>
               </provides>
               <configuration>
-                <jdkHome>${{ env.TOOLCHAIN_JDK }}</jdkHome>
+                <jdkHome>${{ env.CODEQL_JAVA_HOME }}</jdkHome>
               </configuration>
           </toolchain>
         </toolchains>

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -88,7 +88,7 @@ jobs:
 
     - if: matrix.language == 'java'
       name: Build With Maven
-      run: mvn clean install
+      run: ls
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -86,9 +86,9 @@ jobs:
         distribution: 'adopt-openj9'
         java-version: ${{ matrix.java }}
 
-    - if: matrix.language == 'java'
-      name: Build With Maven
-      run: cd dashboard-server && mvn clean install
+    #- if: matrix.language == 'java'
+    #  name: Build With Maven
+    #  run: cd dashboard-server && mvn clean install
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -112,9 +112,7 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+    - run: cd dashboard-server && mvn clean install
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,6 +52,20 @@ jobs:
           maven-${{ matrix.os }}-java${{ matrix.java }}-
           maven-${{ matrix.os }}-
 
+    #- if: matrix.language == 'java'
+    #  name: Build With Maven
+    #  run: cd dashboard-server && mvn clean install
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
     - name: Set Up Toolchain XML
       if: ${{ matrix.java == '11' }}
       shell: bash
@@ -72,20 +86,6 @@ jobs:
           </toolchain>
         </toolchains>
         EOF
-
-    #- if: matrix.language == 'java'
-    #  name: Build With Maven
-    #  run: cd dashboard-server && mvn clean install
-
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -80,12 +80,6 @@ jobs:
         </toolchains>
         EOF
 
-    - name: Set Up JDK
-      uses: actions/setup-java@v2.2.0
-      with:
-        distribution: 'adopt-openj9'
-        java-version: ${{ matrix.java }}
-
     #- if: matrix.language == 'java'
     #  name: Build With Maven
     #  run: cd dashboard-server && mvn clean install

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -83,7 +83,7 @@ jobs:
     - name: Set Up JDK
       uses: actions/setup-java@v2.2.0
       with:
-        distribution: 'adopt-open'
+        distribution: 'adopt'
         java-version: ${{ matrix.java }}
 
     - if: matrix.language == 'java'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -88,7 +88,7 @@ jobs:
 
     - if: matrix.language == 'java'
       name: Build With Maven
-      run: ls
+      run: cd dashboard-server && mvn clean install
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -56,7 +56,7 @@ jobs:
       if: ${{ matrix.java == '11' }}
       uses: battila7/jdk-via-jabba@v1.3.0
       with:
-        jdk: adopt-openj9@1.11.0-11
+        jdk: adopt-openj9@11.0.5-1
         javaHomeEnvironmentVariable: TOOLCHAIN_JDK
 
     - name: Set Up Toolchain XML

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -71,7 +71,7 @@ jobs:
             <type>jdk</type>
               <provides>
                 <version>11</version>
-                <vendor>adopt</vendor>
+                <vendor>adoptopenjdk</vendor>
               </provides>
               <configuration>
                 <jdkHome>${{ env.TOOLCHAIN_JDK }}</jdkHome>
@@ -83,7 +83,7 @@ jobs:
     - name: Set Up JDK
       uses: actions/setup-java@v2.2.0
       with:
-        distribution: 'adopt'
+        distribution: 'adopt-openj9'
         java-version: ${{ matrix.java }}
 
     - if: matrix.language == 'java'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -102,8 +102,8 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    #- name: Autobuild
-    #  uses: github/codeql-action/autobuild@v1
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -112,9 +112,9 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    - run: |
-        rm -rf ~/.m2/repository/* && \
-        cd dashboard-server && mvn clean install -U -e
+#     - run: |
+#         rm -rf ~/.m2/repository/* && \
+#         cd dashboard-server && mvn clean install -U -e
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         language: [ 'java', 'javascript' ]
         os: [ ubuntu-latest ]
-        java: [8, 11]
+        java: [11]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
@@ -83,9 +83,11 @@ jobs:
     - name: Set Up JDK
       uses: actions/setup-java@v2.2.0
       with:
+        distribution: 'adopt-open'
         java-version: ${{ matrix.java }}
 
-    - name: Build With Maven
+    - if: matrix.language == 'java'
+      name: Build With Maven
       run: mvn clean install
 
     # Initializes the CodeQL tools for scanning.


### PR DESCRIPTION
CodeQL worklow was breaking due to usage of toolchain maven plugin. Replaced autobuild step with custom java installation and build steps using toolchain.xml