### PR TITLE
Add player perf resource

### DIFF
--- a/dashboard-server/src/main/java/com/footballstatsdashboard/FootballDashboardApplication.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/FootballDashboardApplication.java
@@ -12,11 +12,13 @@ import com.footballstatsdashboard.db.CouchbaseDAO;
 import com.footballstatsdashboard.db.UserDAO;
 import com.footballstatsdashboard.db.key.AuthTokenKeyProvider;
 import com.footballstatsdashboard.db.key.ClubKeyProvider;
+import com.footballstatsdashboard.db.key.MatchPerformanceKeyProvider;
 import com.footballstatsdashboard.db.key.PlayerKeyProvider;
 import com.footballstatsdashboard.db.key.ResourceKey;
 import com.footballstatsdashboard.db.key.UserKeyProvider;
 import com.footballstatsdashboard.health.FootballDashboardHealthCheck;
 import com.footballstatsdashboard.resources.ClubResource;
+import com.footballstatsdashboard.resources.MatchPerformanceResource;
 import com.footballstatsdashboard.resources.PlayerResource;
 import com.footballstatsdashboard.resources.UserResource;
 import io.dropwizard.Application;
@@ -77,6 +79,11 @@ public class FootballDashboardApplication extends Application<FootballDashboardC
                 new ClubKeyProvider()
         );
 
+        CouchbaseDAO<ResourceKey> matchPerformanceDAO = new CouchbaseDAO<>(
+                couchbaseClientManager.getBucketContainer(clusterName, bucketName),
+                new MatchPerformanceKeyProvider()
+        );
+
         UserDAO<ResourceKey> userCouchbaseDAO = new UserDAO<>(
                 couchbaseClientManager.getBucketContainer(clusterName, bucketName),
                 couchbaseClientManager.getClusterContainer(clusterName),
@@ -92,6 +99,7 @@ public class FootballDashboardApplication extends Application<FootballDashboardC
         environment.jersey().register(new UserResource(userCouchbaseDAO, authTokenDAO));
         environment.jersey().register(new PlayerResource(playerCouchbaseDAO));
         environment.jersey().register(new ClubResource(clubCouchbaseDAO));
+        environment.jersey().register(new MatchPerformanceResource(matchPerformanceDAO));
 
         // Register OAuth authentication
         environment.jersey()

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/FootballDashboardApplication.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/FootballDashboardApplication.java
@@ -9,6 +9,7 @@ import com.footballstatsdashboard.core.utils.PlayerInternalModule;
 import com.footballstatsdashboard.db.AuthTokenDAO;
 import com.footballstatsdashboard.db.ClubDAO;
 import com.footballstatsdashboard.db.CouchbaseDAO;
+import com.footballstatsdashboard.db.MatchPerformanceDAO;
 import com.footballstatsdashboard.db.UserDAO;
 import com.footballstatsdashboard.db.key.AuthTokenKeyProvider;
 import com.footballstatsdashboard.db.key.ClubKeyProvider;
@@ -79,8 +80,9 @@ public class FootballDashboardApplication extends Application<FootballDashboardC
                 new ClubKeyProvider()
         );
 
-        CouchbaseDAO<ResourceKey> matchPerformanceDAO = new CouchbaseDAO<>(
+        MatchPerformanceDAO<ResourceKey> matchPerformanceDAO = new MatchPerformanceDAO<>(
                 couchbaseClientManager.getBucketContainer(clusterName, bucketName),
+                couchbaseClientManager.getClusterContainer(clusterName),
                 new MatchPerformanceKeyProvider()
         );
 

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/MatchPerformance.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/MatchPerformance.java
@@ -1,0 +1,152 @@
+package com.footballstatsdashboard.api.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.footballstatsdashboard.api.model.matchPerformance.MatchRating;
+import com.footballstatsdashboard.core.utils.InternalField;
+import org.immutables.value.Value;
+
+import javax.annotation.Nullable;
+import javax.validation.Valid;
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Value.Immutable
+@JsonSerialize
+@JsonDeserialize(as = ImmutableMatchPerformance.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public interface MatchPerformance {
+
+    /**
+     * match performance ID
+     */
+    @Valid
+    @Value.Default
+    default UUID getId() { return UUID.randomUUID(); }
+
+    /**
+     *  player ID
+     */
+    @Valid
+    UUID getPlayerId();
+
+    /**
+     * competition ID
+     */
+    @Valid
+    UUID getCompetitionId();
+
+    /**
+     * Number of appearances made in the competition by the player
+     */
+    @Valid
+    Integer getAppearances();
+
+    /**
+     * Number of goals scored in the competition by the player
+     */
+    @Valid
+    Integer getGoals();
+
+    /**
+     * Number of penalties scored in the competition by the player
+     */
+    @Valid
+    Integer getPenalties();
+
+    /**
+     * Number of assists made in the competition by the player
+     */
+    @Valid
+    Integer getAssists();
+
+    /**
+     * Number of Player of the Match awards won in the competition by the player
+     */
+    @Valid
+    Integer getPlayerOfTheMatch();
+
+    /**
+     * Number of yellow cards accumulated in the competition by the player
+     */
+    @Valid
+    Integer getYellowCards();
+
+    /**
+     * Number of red cards accumulated in the competition by the player
+     */
+    @Valid
+    Integer getRedCards();
+
+    /**
+     * Number of tackles made in the competition by the player
+     */
+    @Valid
+    Integer getTackles();
+
+    /**
+     * Number of fouls committed in the competition by the player
+     */
+    @Valid
+    Integer getFouls();
+
+    /**
+     * Number of dribbles completed in the competition by the player
+     */
+    @Valid
+    Integer getDribbles();
+
+    /**
+     * Player's pass completion rate in the competition
+     */
+    @Valid
+    Float getPassCompletionRate();
+
+    /**
+     * Player's match rating in the competition
+     */
+    @Valid
+    MatchRating getMatchRating();
+
+    // TODO: 12/05/21 update all local date times to zoned date times to involve timezones as well
+    /**
+     * timestamp when player data was created
+     */
+    @Valid
+    @Nullable
+    @InternalField
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    @JsonSerialize(using = LocalDateSerializer.class)
+    LocalDate getCreatedDate();
+
+    /**
+     * timestamp when player data was last modified
+     */
+    @Valid
+    @Nullable
+    @InternalField
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    @JsonSerialize(using = LocalDateSerializer.class)
+    LocalDate getLastModifiedDate();
+
+    /**
+     * represents entity that requested player data be created
+     */
+    @Nullable
+    @InternalField
+    String getCreatedBy();
+
+    /**
+     * represent the type of entity
+     */
+    @Nullable
+    @InternalField
+    @Value.Default
+    default String getType() { return "MatchPerformance"; }
+}

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/club/SquadPlayer.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/club/SquadPlayer.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
 import javax.validation.Valid;
+import java.util.List;
 import java.util.UUID;
 
 @Value.Immutable
@@ -37,6 +38,12 @@ public interface SquadPlayer {
      */
     @Valid
     Integer getCurrentAbility();
+
+    /**
+     * Player's form in recent matches
+     */
+    @Valid
+    List<Float> getRecentForm();
 
     /**
      * Player's ID

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/matchPerformance/MatchRating.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/matchPerformance/MatchRating.java
@@ -1,0 +1,25 @@
+package com.footballstatsdashboard.api.model.matchPerformance;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Size;
+import java.util.List;
+
+@Value.Immutable
+@JsonSerialize
+@JsonDeserialize(as = ImmutableMatchRating.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Value.Style(jdkOnly = true) // Required if the below entity will be used in a Map, List, Set or any other collection
+public interface MatchRating {
+
+    @Valid
+    Float getCurrent();
+
+    @Valid
+    @Size(min = 1)
+    List<Float> getHistory();
+}

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/core/utils/Constants.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/core/utils/Constants.java
@@ -18,4 +18,8 @@ public final class Constants {
     public static final String CLUB_V1_BASE_PATH = "football-stats-dashboard/v1/club";
     public static final String CLUB_ID = "clubId";
     public static final String CLUB_ID_PATH = "/{" + CLUB_ID + "}";
+
+    public static final String MATCH_PERFORMANCE_V1_BASE_PATH = "football-stats-dashboard/v1/match-performance";
+    public static final String MATCH_PERFORMANCE_ID = "matchPerformanceId";
+    public static final String MATCH_PERFORMANCE_ID_PATH = "/{" + MATCH_PERFORMANCE_ID + "}";
 }

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/db/MatchPerformanceDAO.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/db/MatchPerformanceDAO.java
@@ -1,0 +1,36 @@
+package com.footballstatsdashboard.db;
+
+import com.couchbase.client.java.json.JsonObject;
+import com.couchbase.client.java.query.QueryOptions;
+import com.couchbase.client.java.query.QueryResult;
+import com.footballstatsdashboard.api.model.MatchPerformance;
+import com.footballstatsdashboard.client.couchbase.CouchbaseClientManager;
+import com.footballstatsdashboard.db.key.CouchbaseKeyProvider;
+
+import java.util.List;
+import java.util.UUID;
+
+public class MatchPerformanceDAO<K> extends CouchbaseDAO<K> {
+    private final CouchbaseClientManager.ClusterContainer clusterContainer;
+
+    public MatchPerformanceDAO(CouchbaseClientManager.BucketContainer bucketContainer,
+                               CouchbaseClientManager.ClusterContainer clusterContainer,
+                               CouchbaseKeyProvider<K> couchbaseKeyProvider) {
+        super(bucketContainer, couchbaseKeyProvider);
+        this.clusterContainer = clusterContainer;
+    }
+
+    public MatchPerformance lookupMatchPerformanceByPlayerId(UUID playerId, UUID competitionId) {
+        String query = String.format("Select matchPerformance.* from `%s` matchPerformance" +
+                " where playerId = $playerId and competitionId = $competitionId", this.getBucketNameResolver().get());
+
+        QueryOptions queryOptions = QueryOptions.queryOptions().parameters(
+                JsonObject.create()
+                        .put("playerId", playerId.toString())
+                        .put("competitionId", competitionId.toString())
+        );
+        QueryResult queryResult = this.clusterContainer.getCluster().query(query, queryOptions);
+        List<MatchPerformance> matchPerformanceList = queryResult.rowsAs(MatchPerformance.class);
+        return matchPerformanceList.stream().findFirst().orElse(null);
+    }
+}

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/db/key/MatchPerformanceKeyProvider.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/db/key/MatchPerformanceKeyProvider.java
@@ -1,0 +1,7 @@
+package com.footballstatsdashboard.db.key;
+
+public class MatchPerformanceKeyProvider extends  BaseKeyProvider {
+
+    @Override
+    protected String getResourceName() { return "matchPerformance"; }
+}

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/resources/MatchPerformanceResource.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/resources/MatchPerformanceResource.java
@@ -1,0 +1,151 @@
+package com.footballstatsdashboard.resources;
+
+import com.footballstatsdashboard.api.model.ImmutableMatchPerformance;
+import com.footballstatsdashboard.api.model.MatchPerformance;
+import com.footballstatsdashboard.api.model.User;
+import com.footballstatsdashboard.api.model.matchPerformance.ImmutableMatchRating;
+import com.footballstatsdashboard.api.model.matchPerformance.MatchRating;
+import com.footballstatsdashboard.db.CouchbaseDAO;
+import com.footballstatsdashboard.db.key.ResourceKey;
+import com.google.common.collect.ImmutableList;
+import io.dropwizard.auth.Auth;
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.validation.Valid;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.UUID;
+
+import static com.footballstatsdashboard.core.utils.Constants.MATCH_PERFORMANCE_ID;
+import static com.footballstatsdashboard.core.utils.Constants.MATCH_PERFORMANCE_ID_PATH;
+import static com.footballstatsdashboard.core.utils.Constants.MATCH_PERFORMANCE_V1_BASE_PATH;
+
+@Path(MATCH_PERFORMANCE_V1_BASE_PATH)
+@Produces(MediaType.APPLICATION_JSON)
+public class MatchPerformanceResource {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClubResource.class);
+
+    private final CouchbaseDAO<ResourceKey> couchbaseDAO;
+
+    public MatchPerformanceResource(CouchbaseDAO<ResourceKey> couchbaseDAO) {
+        this.couchbaseDAO = couchbaseDAO;
+    }
+
+    @GET
+    @Path(MATCH_PERFORMANCE_ID_PATH)
+    public Response getMatchPerformance(
+            @Auth @PathParam(MATCH_PERFORMANCE_ID) UUID matchPerformanceId) {
+
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("getMatchPerformance() request for match performance ID: {}", matchPerformanceId);
+        }
+
+        ResourceKey resourceKey = new ResourceKey(matchPerformanceId);
+        MatchPerformance matchPerformance =
+                this.couchbaseDAO.getDocument(resourceKey, MatchPerformance.class).getLeft();
+        return Response.ok().entity(matchPerformance).build();
+    }
+
+    @POST
+    public Response createMatchPerformance(
+            @Auth User user,
+            @Valid MatchPerformance incomingMatchPerformance,
+            @Context UriInfo uriInfo) {
+
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("createMatchPerformance() request.");
+        }
+
+        // TODO: 17/04/21 add more internal data when business logic becomes complicated
+        LocalDate currentDate = LocalDate.now();
+        MatchPerformance newMatchPerformance = ImmutableMatchPerformance.builder()
+                .from(incomingMatchPerformance)
+                .createdDate(currentDate)
+                .lastModifiedDate(currentDate)
+                .createdBy(user.getEmail())
+                .build();
+
+        ResourceKey resourceKey = new ResourceKey(newMatchPerformance.getId());
+        this.couchbaseDAO.insertDocument(resourceKey, newMatchPerformance);
+
+        URI location = uriInfo.getAbsolutePathBuilder().path(newMatchPerformance.getId().toString()).build();
+        return Response.created(location).entity(new HashMap<>()).build();
+    }
+
+    @PUT
+    @Path(MATCH_PERFORMANCE_ID_PATH)
+    public Response updateMatchPerformance(
+            @Auth @PathParam(MATCH_PERFORMANCE_ID) UUID existingMatchPerformanceId,
+            @Valid MatchPerformance incomingMatchPerformance) {
+
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("updateMatchPerformance() request for match performance ID: {}", existingMatchPerformanceId);
+        }
+
+        ResourceKey resourceKey = new ResourceKey(existingMatchPerformanceId);
+        Pair<MatchPerformance, Long> existingMatchPerformanceEntity = this.couchbaseDAO.getDocument(resourceKey,
+                MatchPerformance.class);
+        MatchPerformance existingMatchPerformance = existingMatchPerformanceEntity.getLeft();
+
+        if (existingMatchPerformance.getId().equals(incomingMatchPerformance.getId())) {
+            MatchPerformance updatedMatchPerformance = ImmutableMatchPerformance.builder()
+                    .from(existingMatchPerformance)
+                    .appearances(incomingMatchPerformance.getAppearances())
+                    .goals(incomingMatchPerformance.getGoals())
+                    .dribbles(incomingMatchPerformance.getDribbles())
+                    .passCompletionRate(incomingMatchPerformance.getPassCompletionRate())
+                    .assists(incomingMatchPerformance.getAssists())
+                    .yellowCards(incomingMatchPerformance.getYellowCards())
+                    .redCards(incomingMatchPerformance.getRedCards())
+                    .tackles(incomingMatchPerformance.getTackles())
+                    .matchRating(incomingMatchPerformance.getMatchRating())
+                    .playerOfTheMatch(incomingMatchPerformance.getPlayerOfTheMatch())
+                    .penalties(incomingMatchPerformance.getPenalties())
+                    .fouls(incomingMatchPerformance.getFouls())
+                    .lastModifiedDate(LocalDate.now())
+                    .build();
+
+            this.couchbaseDAO.updateDocument(resourceKey, updatedMatchPerformance,
+                    existingMatchPerformanceEntity.getRight());
+            return Response.ok().entity(updatedMatchPerformance).build();
+        }
+
+        LOGGER.error("Incoming match performance entity ID: {} does not matching ID of existing match performance " +
+                        "entity in couchbase: {}. Aborting operation!",
+                incomingMatchPerformance.getId(), existingMatchPerformance.getId());
+        return Response.serverError()
+                .entity("Unable to update match performance with ID: " + incomingMatchPerformance.getId().toString())
+                .build();
+    }
+
+    @DELETE
+    @Path(MATCH_PERFORMANCE_ID_PATH)
+    public Response deleteMatchPerformance(
+            @Auth @PathParam(MATCH_PERFORMANCE_ID) UUID matchPerformanceId) {
+
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("deleteMatchPerformance() request for match performance entity with ID: {}",
+                    matchPerformanceId);
+        }
+
+        ResourceKey resourceKey = new ResourceKey(matchPerformanceId);
+        this.couchbaseDAO.deleteDocument(resourceKey);
+
+        return Response.noContent().build();
+    }
+}

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/resources/MatchPerformanceResource.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/resources/MatchPerformanceResource.java
@@ -3,11 +3,8 @@ package com.footballstatsdashboard.resources;
 import com.footballstatsdashboard.api.model.ImmutableMatchPerformance;
 import com.footballstatsdashboard.api.model.MatchPerformance;
 import com.footballstatsdashboard.api.model.User;
-import com.footballstatsdashboard.api.model.matchPerformance.ImmutableMatchRating;
-import com.footballstatsdashboard.api.model.matchPerformance.MatchRating;
-import com.footballstatsdashboard.db.CouchbaseDAO;
+import com.footballstatsdashboard.db.MatchPerformanceDAO;
 import com.footballstatsdashboard.db.key.ResourceKey;
-import com.google.common.collect.ImmutableList;
 import io.dropwizard.auth.Auth;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
@@ -34,16 +31,17 @@ import java.util.UUID;
 import static com.footballstatsdashboard.core.utils.Constants.MATCH_PERFORMANCE_ID;
 import static com.footballstatsdashboard.core.utils.Constants.MATCH_PERFORMANCE_ID_PATH;
 import static com.footballstatsdashboard.core.utils.Constants.MATCH_PERFORMANCE_V1_BASE_PATH;
+import static com.footballstatsdashboard.core.utils.Constants.PLAYER_ID;
 
 @Path(MATCH_PERFORMANCE_V1_BASE_PATH)
 @Produces(MediaType.APPLICATION_JSON)
 public class MatchPerformanceResource {
     private static final Logger LOGGER = LoggerFactory.getLogger(ClubResource.class);
 
-    private final CouchbaseDAO<ResourceKey> couchbaseDAO;
+    private final MatchPerformanceDAO<ResourceKey> matchPerformanceDAO;
 
-    public MatchPerformanceResource(CouchbaseDAO<ResourceKey> couchbaseDAO) {
-        this.couchbaseDAO = couchbaseDAO;
+    public MatchPerformanceResource(MatchPerformanceDAO<ResourceKey> matchPerformanceDAO) {
+        this.matchPerformanceDAO = matchPerformanceDAO;
     }
 
     @GET
@@ -57,7 +55,7 @@ public class MatchPerformanceResource {
 
         ResourceKey resourceKey = new ResourceKey(matchPerformanceId);
         MatchPerformance matchPerformance =
-                this.couchbaseDAO.getDocument(resourceKey, MatchPerformance.class).getLeft();
+                this.matchPerformanceDAO.getDocument(resourceKey, MatchPerformance.class).getLeft();
         return Response.ok().entity(matchPerformance).build();
     }
 
@@ -81,7 +79,7 @@ public class MatchPerformanceResource {
                 .build();
 
         ResourceKey resourceKey = new ResourceKey(newMatchPerformance.getId());
-        this.couchbaseDAO.insertDocument(resourceKey, newMatchPerformance);
+        this.matchPerformanceDAO.insertDocument(resourceKey, newMatchPerformance);
 
         URI location = uriInfo.getAbsolutePathBuilder().path(newMatchPerformance.getId().toString()).build();
         return Response.created(location).entity(new HashMap<>()).build();
@@ -98,7 +96,7 @@ public class MatchPerformanceResource {
         }
 
         ResourceKey resourceKey = new ResourceKey(existingMatchPerformanceId);
-        Pair<MatchPerformance, Long> existingMatchPerformanceEntity = this.couchbaseDAO.getDocument(resourceKey,
+        Pair<MatchPerformance, Long> existingMatchPerformanceEntity = this.matchPerformanceDAO.getDocument(resourceKey,
                 MatchPerformance.class);
         MatchPerformance existingMatchPerformance = existingMatchPerformanceEntity.getLeft();
 
@@ -120,7 +118,7 @@ public class MatchPerformanceResource {
                     .lastModifiedDate(LocalDate.now())
                     .build();
 
-            this.couchbaseDAO.updateDocument(resourceKey, updatedMatchPerformance,
+            this.matchPerformanceDAO.updateDocument(resourceKey, updatedMatchPerformance,
                     existingMatchPerformanceEntity.getRight());
             return Response.ok().entity(updatedMatchPerformance).build();
         }

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/resources/MatchPerformanceResource.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/resources/MatchPerformanceResource.java
@@ -18,6 +18,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -142,8 +143,27 @@ public class MatchPerformanceResource {
         }
 
         ResourceKey resourceKey = new ResourceKey(matchPerformanceId);
-        this.couchbaseDAO.deleteDocument(resourceKey);
+        this.matchPerformanceDAO.deleteDocument(resourceKey);
 
         return Response.noContent().build();
+    }
+
+    @GET
+    @Path("lookup/{playerId}")
+    public Response lookupMatchPerformanceByPlayerId(
+            @Auth @PathParam(PLAYER_ID) UUID playerId,
+            @QueryParam("competitionId") UUID competitionId) {
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("getMatchPerformanceByPlayerId() request made!");
+        }
+        MatchPerformance matchPerformance = this.matchPerformanceDAO.lookupMatchPerformanceByPlayerId(playerId,
+                competitionId);
+        if (matchPerformance != null) {
+            return Response.ok().entity(matchPerformance).build();
+        }
+
+        LOGGER.error("Unable to fetch match performance data associated with playerId: {} and competitionId: {}",
+                playerId, competitionId);
+        return Response.status(Response.Status.NOT_FOUND).build();
     }
 }

--- a/dashboard-server/src/main/resources/api/api.raml
+++ b/dashboard-server/src/main/resources/api/api.raml
@@ -174,7 +174,7 @@ securitySchemes:
           application/json:
             example: !include examples/club-response.json
 
-/matchPerformance:
+/match-performance:
   /{matchPerformanceId}:
     uriParameters:
       matchPerformanceId:

--- a/dashboard-server/src/main/resources/api/api.raml
+++ b/dashboard-server/src/main/resources/api/api.raml
@@ -219,7 +219,7 @@ securitySchemes:
             example: !include examples/match-performance-response.json
       422:
         description: unprocessable entity when playerID or competitionID is missing
-  /{playerId}:
+  /lookup/{playerId}:
     uriParameters:
       playerId:
         description: The player ID

--- a/dashboard-server/src/main/resources/api/api.raml
+++ b/dashboard-server/src/main/resources/api/api.raml
@@ -173,3 +173,69 @@ securitySchemes:
         body:
           application/json:
             example: !include examples/club-response.json
+
+/matchPerformance:
+  /{matchPerformanceId}:
+    uriParameters:
+      matchPerformanceId:
+        description: The identifier for the match performance corresponding to a player and a competition
+        type: string
+        required: true
+    get:
+      description: gets a player's performance data in a given competition on the basis of the performance ID
+      securedBy: [access_token]
+      responses:
+        200:
+          body:
+            application/json:
+              example: !include examples/match-performance-response.json
+    put:
+      description: updates a player's performance data in a given competition on the basis of the performance ID
+      securedBy: [access_token]
+      responses:
+        200:
+          body:
+            application/json:
+              example: !include examples/match-performance-response.json
+        500:
+          description: failed during player performance data update
+    delete:
+      description: delete a player's performance data in a given competition on the basis of the performance ID
+      securedBy: [access_token]
+      responses:
+        204:
+          description: successfully delete a player's performance data
+  post:
+    description: add new match performance data for a given player in a give competition
+    securedBy: [access_token]
+    body:
+      application/json:
+        example: !include examples/match-performance-post-request.json
+    responses:
+      201:
+        description: player's match performance data created
+        body:
+          application/json:
+            example: !include examples/match-performance-response.json
+      422:
+        description: unprocessable entity when playerID or competitionID is missing
+  /{playerId}:
+    uriParameters:
+      playerId:
+        description: The player ID
+        type: string
+        required: true
+    get:
+      description: gets a player's performance data based on their ID and the competitionID
+      securedBy: [access_token]
+      queryParameters:
+        competitionId:
+          displayName: Competition ID
+          type: string
+          required: false
+          description: The competition identifier
+      responses:
+        200:
+          body:
+            application/json:
+              example: !include examples/match-performance-response.json

--- a/dashboard-server/src/main/resources/api/examples/match-performance-post-request.json
+++ b/dashboard-server/src/main/resources/api/examples/match-performance-post-request.json
@@ -1,0 +1,30 @@
+{
+  "playerId": "091417ca-14ef-404c-9162-64f57ed84835",
+  "competitionId": "daf48153-143b-4d5a-9422-9a5829ce7ccb",
+  "appearances": 10,
+  "goals": 5,
+  "penalties": 0,
+  "assists": 2,
+  "playerOfTheMatch": 0,
+  "yellowCards": 0,
+  "redCards": 1,
+  "tackles": 10,
+  "fouls": 3,
+  "dribbles": 14,
+  "passCompletionRate": 70.0,
+  "matchRating": {
+    "current": 7.5,
+    "history": [
+      4,
+      5,
+      8,
+      6,
+      9,
+      4,
+      9,
+      2,
+      2,
+      3
+    ]
+  }
+}

--- a/dashboard-server/src/main/resources/api/examples/match-performance-response.json
+++ b/dashboard-server/src/main/resources/api/examples/match-performance-response.json
@@ -1,0 +1,31 @@
+{
+  "id": "cb19b417-5716-412f-9212-b338ffeca0fd",
+  "playerId": "091417ca-14ef-404c-9162-64f57ed84835",
+  "competitionId": "daf48153-143b-4d5a-9422-9a5829ce7ccb",
+  "appearances": 10,
+  "goals": 5,
+  "penalties": 0,
+  "assists": 2,
+  "playerOfTheMatch": 0,
+  "yellowCards": 0,
+  "redCards": 1,
+  "tackles": 10,
+  "fouls": 3,
+  "dribbles": 14,
+  "passCompletionRate": 70.0,
+  "matchRating": {
+    "current": 7.5,
+    "history": [
+      4,
+      5,
+      8,
+      6,
+      9,
+      4,
+      9,
+      2,
+      2,
+      3
+    ]
+  }
+}

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/ClubResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/ClubResourceTest.java
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.when;
 public class ClubResourceTest {
     private static final String URI_PATH = "/club";
     private static final ObjectMapper OBJECT_MAPPER = Jackson.newObjectMapper().copy();
-    public static final String USER_EMAIL = "fake email";
+    private static final String USER_EMAIL = "fake email";
     private User userPrincipal;
 
     private ClubResource clubResource;
@@ -163,8 +163,10 @@ public class ClubResourceTest {
         UUID existingClubId = UUID.randomUUID();
         Long existingClubCAS = 123L;
         Club existingClubInCouchbase = getClubDataStub(existingClubId, true);
-        Club incomingClub = ImmutableClub.builder().from(getClubDataStub(existingClubId, false))
-                .wageBudget(BigDecimal.valueOf(300))
+        BigDecimal updatedWageBudget = existingClubInCouchbase.getWageBudget().add(BigDecimal.valueOf(100));
+        Club incomingClub = ImmutableClub.builder()
+                .from(getClubDataStub(existingClubId, false))
+                .wageBudget(updatedWageBudget)
                 .build();
         ArgumentCaptor<ResourceKey> resourceKeyCaptor = ArgumentCaptor.forClass(ResourceKey.class);
         ArgumentCaptor<Club> updatedClubCaptor = ArgumentCaptor.forClass(Club.class);
@@ -182,14 +184,14 @@ public class ClubResourceTest {
         Club clubToBeUpdatedInCouchbase = updatedClubCaptor.getValue();
         assertNotNull(clubToBeUpdatedInCouchbase);
         assertEquals(userPrincipal.getEmail(), clubToBeUpdatedInCouchbase.getCreatedBy());
-        assertNotEquals(existingClubInCouchbase.getLastModifiedDate(), clubToBeUpdatedInCouchbase.getLastModifiedDate());
+        assertEquals(LocalDate.now(), clubToBeUpdatedInCouchbase.getLastModifiedDate());
 
         assertEquals(HttpStatus.OK_200, clubResponse.getStatus());
         assertNotNull(clubResponse.getEntity());
 
         Club clubInResponse = OBJECT_MAPPER.convertValue(clubResponse.getEntity(), Club.class);
         assertEquals(existingClubInCouchbase.getId(), clubInResponse.getId());
-        assertEquals(incomingClub.getWageBudget(), clubInResponse.getWageBudget());
+        assertEquals(updatedWageBudget, clubInResponse.getWageBudget());
         assertEquals(userPrincipal.getEmail(), clubInResponse.getCreatedBy());
     }
 
@@ -201,9 +203,9 @@ public class ClubResourceTest {
     public void updateClub_incomingClubIdDoesNotMatchExisting() {
         // setup
         UUID existingClubId = UUID.randomUUID();
-        Long existingClubCas = 123L;
+        Long existingClubCAS = 123L;
         Club existingClubInCouchbase = getClubDataStub(existingClubId, true);
-        when(clubDAO.getDocument(any(), any())).thenReturn(Pair.of(existingClubInCouchbase, existingClubCas));
+        when(clubDAO.getDocument(any(), any())).thenReturn(Pair.of(existingClubInCouchbase, existingClubCAS));
 
         UUID incorrectIncomingClubId = UUID.randomUUID();
         Club incomingClub = ImmutableClub.builder()

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/ClubResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/ClubResourceTest.java
@@ -27,6 +27,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -253,6 +254,7 @@ public class ClubResourceTest {
                 .country("fake player country")
                 .role("fake player role")
                 .currentAbility(19)
+                .recentForm(new ArrayList<>())
                 .playerId(UUID.randomUUID())
                 .build();
         when(clubDAO.getPlayersInClub(eq(clubId))).thenReturn(ImmutableList.of(expectedSquadPlayer));

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/MatchPerformanceResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/MatchPerformanceResourceTest.java
@@ -1,0 +1,291 @@
+package com.footballstatsdashboard.resources;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.footballstatsdashboard.api.model.ImmutableMatchPerformance;
+import com.footballstatsdashboard.api.model.ImmutableUser;
+import com.footballstatsdashboard.api.model.MatchPerformance;
+import com.footballstatsdashboard.api.model.User;
+import com.footballstatsdashboard.api.model.matchPerformance.ImmutableMatchRating;
+import com.footballstatsdashboard.api.model.matchPerformance.MatchRating;
+import com.footballstatsdashboard.db.CouchbaseDAO;
+import com.footballstatsdashboard.db.key.ResourceKey;
+import com.google.common.collect.ImmutableList;
+import io.dropwizard.jackson.Jackson;
+import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for match performance resource
+ */
+public class MatchPerformanceResourceTest {
+    private static final String URI_PATH = "/match-performance";
+    private static final ObjectMapper OBJECT_MAPPER = Jackson.newObjectMapper().copy();
+    private static final String USER_EMAIL = "fake email";
+    private User userPrincipal;
+
+    private MatchPerformanceResource matchPerformanceResource;
+
+    @Mock
+    private CouchbaseDAO<ResourceKey> couchbaseDAO;
+
+    @Mock
+    private UriInfo uriInfo;
+
+    @Before
+    public void initialize() {
+        MockitoAnnotations.openMocks(this);
+
+        // TODO: 19/08/21 create base UT for all resources to encapsulat this common code
+        UriBuilder uriBuilder = UriBuilder.fromPath(URI_PATH);
+        when(uriInfo.getAbsolutePathBuilder()).thenReturn(uriBuilder);
+
+        userPrincipal = ImmutableUser.builder()
+                .email(USER_EMAIL)
+                // other details are not required for the purposes of this test, so using empty strings
+                .password("")
+                .firstName("")
+                .lastName("")
+                .build();
+        matchPerformanceResource = new MatchPerformanceResource(couchbaseDAO);
+    }
+
+    /**
+     * given a valid match performance id, tests that the match performance data is successfully fetched from
+     * couchbase server and returned in the response
+     */
+    @Test
+    public void getMatchPerformance_fetchesMatchPerformanceDataFromCouchbase() {
+        // setup
+        UUID matchPerformanceId = UUID.randomUUID();
+        MatchPerformance matchPerformanceFromCouchbase = getMatchPerformanceDataStub(matchPerformanceId, false);
+        when(couchbaseDAO.getDocument(any(), any())).thenReturn(Pair.of(matchPerformanceFromCouchbase, 123L));
+
+        // execute
+        Response matchPerformanceResponse = matchPerformanceResource.getMatchPerformance(matchPerformanceId);
+
+        // TODO: 19/08/21 refactor common assertions into an assertion helper
+        // assert
+        verify(couchbaseDAO).getDocument(any(), any());
+
+        assertNotNull(matchPerformanceResponse);
+        assertEquals(HttpStatus.OK_200, matchPerformanceResponse.getStatus());
+        assertNotNull(matchPerformanceResponse.getEntity());
+
+        MatchPerformance matchPerformanceFromResponse = OBJECT_MAPPER.convertValue(matchPerformanceResponse.getEntity(),
+                MatchPerformance.class);
+        assertEquals(matchPerformanceId, matchPerformanceFromResponse.getId());
+    }
+
+    /**
+     * given a runtime exception is thrown by couchbase DAO when match performance data is not found, verifies
+     * that the same exception is thrown by `getClub` resource method as well
+     */
+    @Test(expected = RuntimeException.class)
+    public void getMatchPerformance_matchPerformanceNotFoundInCouchbase() {
+        // setup
+        UUID invalidMatchPerformanceId = UUID.randomUUID();
+        when(couchbaseDAO.getDocument(any(), any()))
+                .thenThrow(new RuntimeException("Unable to find document with ID: " + invalidMatchPerformanceId));
+
+        // execute
+        matchPerformanceResource.getMatchPerformance(invalidMatchPerformanceId);
+
+        // assert
+        verify(couchbaseDAO).getDocument(any(), any());
+    }
+
+    /**
+     * given a valid match performance entity in the request, tests that the internal fields are set correctly on the
+     * entity and persisted in couchbase
+     */
+    @Test
+    public void createMatchPerformance_persistsMatchPerformanceInCouchbase() {
+        // setup
+        MatchPerformance incomingMatchPerformance = getMatchPerformanceDataStub(null, false);
+        ArgumentCaptor<MatchPerformance> newMatchPerformanceCaptor = ArgumentCaptor.forClass(MatchPerformance.class);
+
+        // execute
+        Response matchPerformanceResponse = matchPerformanceResource.createMatchPerformance(userPrincipal,
+                incomingMatchPerformance, uriInfo);
+
+        // assert
+        verify(couchbaseDAO).insertDocument(any(), newMatchPerformanceCaptor.capture());
+        MatchPerformance capturedMatchPerformance = newMatchPerformanceCaptor.getValue();
+        assertNotNull(capturedMatchPerformance);
+        assertNotNull(capturedMatchPerformance.getCreatedDate());
+        assertNotNull(capturedMatchPerformance.getLastModifiedDate());
+        assertEquals(USER_EMAIL, capturedMatchPerformance.getCreatedBy());
+
+        assertNotNull(matchPerformanceResponse);
+        assertEquals(HttpStatus.CREATED_201, matchPerformanceResponse.getStatus());
+        assertNotNull(matchPerformanceResponse.getEntity());
+
+        // a matchPerformanceId is set on the matchPerformance instance created despite not setting one explicitly
+        // due to the way the interface has been set up
+        assertEquals(URI_PATH + "/" + incomingMatchPerformance.getId().toString(),
+                matchPerformanceResponse.getLocation().getPath());
+    }
+
+    /**
+     * given a valid match performance entity in the request, tests that an updated club entity with update internal
+     * fields is upserted in couchbase
+     */
+    @Test
+    public void updateMatchPerformance_updatesMatchPerformanceInCouchbase() {
+        // setup
+        UUID existingMatchPerformanceId = UUID.randomUUID();
+        Long existingMatchPerformanceCAS = 123L;
+        MatchPerformance existingMatchPerformanceInCouchbase = getMatchPerformanceDataStub(existingMatchPerformanceId,
+                true);
+        int updatedAppearances = existingMatchPerformanceInCouchbase.getAppearances() + 10;
+        MatchPerformance incomingMatchPerformance = ImmutableMatchPerformance.builder()
+                .from(getMatchPerformanceDataStub(null, false))
+                .appearances(updatedAppearances)
+                .build();
+
+        ArgumentCaptor<ResourceKey> resourceKeyCaptor = ArgumentCaptor.forClass(ResourceKey.class);
+        when(couchbaseDAO.getDocument(any(), any())).thenReturn(Pair.of(existingMatchPerformanceInCouchbase,
+                existingMatchPerformanceCAS));
+
+        ArgumentCaptor<MatchPerformance> matchPerformanceToBeUpdatedCaptor =
+                ArgumentCaptor.forClass(MatchPerformance.class);
+
+        // execute
+        Response matchPerformanceResponse =
+                matchPerformanceResource.updateMatchPerformance(existingMatchPerformanceId, incomingMatchPerformance);
+
+        // assert
+        verify(couchbaseDAO).getDocument(resourceKeyCaptor.capture(), any());
+        ResourceKey capturedResourceKey = resourceKeyCaptor.getValue();
+        assertEquals(existingMatchPerformanceId, capturedResourceKey.getResourceId());
+
+        verify(couchbaseDAO).updateDocument(eq(capturedResourceKey), matchPerformanceToBeUpdatedCaptor.capture(),
+                eq(existingMatchPerformanceCAS));
+        MatchPerformance matchPerformanceToBeUpdated = matchPerformanceToBeUpdatedCaptor.getValue();
+        assertNotNull(matchPerformanceToBeUpdated);
+        assertEquals(userPrincipal.getEmail(), matchPerformanceToBeUpdated.getCreatedBy());
+        assertEquals(LocalDate.now(), matchPerformanceToBeUpdated.getLastModifiedDate());
+
+        assertNotNull(matchPerformanceResponse);
+        assertEquals(HttpStatus.OK_200, matchPerformanceResponse.getStatus());
+        assertNotNull(matchPerformanceResponse.getEntity());
+
+        MatchPerformance matchPerformanceFromResponse = OBJECT_MAPPER.convertValue(matchPerformanceResponse.getEntity(),
+                MatchPerformance.class);
+        assertEquals(existingMatchPerformanceId, matchPerformanceFromResponse.getId());
+        assertEquals(updatedAppearances, (int) matchPerformanceFromResponse.getAppearances());
+    }
+
+    /**
+     * given that the request contains a match performance entity whose ID does not match the existing match
+     * performance entity's ID, tests that the invalid entity is not upserted in couchbase and a server error
+     * response is returned
+     */
+    @Test
+    public void updateMatchPerformance_incomingMatchPerformanceIdDoesNotMatchExisting() {
+        // setup
+        UUID existingMatchPerformanceId = UUID.randomUUID();
+        Long existingMatchPerformanceCAS = 123L;
+        MatchPerformance existingMatchPerformance = getMatchPerformanceDataStub(existingMatchPerformanceId, true);
+        when(couchbaseDAO.getDocument(any(), any())).thenReturn(Pair.of(existingMatchPerformance,
+                existingMatchPerformanceCAS));
+
+        UUID incorrectMatchPerformanceId = UUID.randomUUID();
+        MatchPerformance incomingMatchPerformance = ImmutableMatchPerformance.builder()
+                .from(existingMatchPerformance)
+                .id(incorrectMatchPerformanceId)
+                .build();
+
+        // execute
+        Response matchPerformanceResponse =
+                matchPerformanceResource.updateMatchPerformance(existingMatchPerformanceId, incomingMatchPerformance);
+
+        // assert
+        verify(couchbaseDAO).getDocument(any(), any());
+        verify(couchbaseDAO, never()).updateDocument(any(), any(), anyLong());
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR_500, matchPerformanceResponse.getStatus());
+        assertTrue(matchPerformanceResponse.getEntity().toString().contains(incorrectMatchPerformanceId.toString()));
+    }
+
+    /**
+     * given a valid match performance ID, removes the match performance entity from couchbase
+     */
+    @Test
+    public void deleteMatchPerformance_removesMatchPerformanceFromCouchbase() {
+        // setup
+        UUID matchPerformanceId = UUID.randomUUID();
+        ArgumentCaptor<ResourceKey> resourceKeyCaptor = ArgumentCaptor.forClass(ResourceKey.class);
+
+        // execute
+        Response matchPerformanceResponse = matchPerformanceResource.deleteMatchPerformance(matchPerformanceId);
+
+        // assert
+        verify(couchbaseDAO).deleteDocument(resourceKeyCaptor.capture());
+        ResourceKey capturedResourceKey = resourceKeyCaptor.getValue();
+        assertNotNull(capturedResourceKey);
+        assertEquals(matchPerformanceId, capturedResourceKey.getResourceId());
+
+        assertNotNull(matchPerformanceResponse);
+        assertEquals(HttpStatus.NO_CONTENT_204, matchPerformanceResponse.getStatus());
+    }
+
+    private MatchPerformance getMatchPerformanceDataStub(UUID matchPerformanceId, boolean isExisting) {
+        MatchRating matchRatingFromCouchbase = ImmutableMatchRating.builder()
+                .current(7f)
+                .history(ImmutableList.of(3.55f, 4f))
+                .build();
+        ImmutableMatchPerformance.Builder matchPerformanceBuilder = ImmutableMatchPerformance.builder()
+                .playerId(UUID.randomUUID())
+                .competitionId(UUID.randomUUID())
+                .appearances(10)
+                .goals(10)
+                .dribbles(10)
+                .passCompletionRate(80.0f)
+                .assists(10)
+                .yellowCards(10)
+                .redCards(10)
+                .tackles(10)
+                .matchRating(matchRatingFromCouchbase)
+                .playerOfTheMatch(10)
+                .penalties(10)
+                .fouls(10);
+
+        if (matchPerformanceId != null) {
+            matchPerformanceBuilder.id(matchPerformanceId);
+        }
+
+        if (isExisting) {
+            matchPerformanceBuilder.createdBy(USER_EMAIL);
+
+            Instant currentInstant = Instant.now();
+            Instant olderInstant = currentInstant.minus(1, ChronoUnit.DAYS);
+            matchPerformanceBuilder.lastModifiedDate(LocalDate.ofInstant(olderInstant, ZoneId.systemDefault()));
+        }
+        return matchPerformanceBuilder.build();
+    }
+}

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/MatchPerformanceResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/MatchPerformanceResourceTest.java
@@ -163,7 +163,7 @@ public class MatchPerformanceResourceTest {
                 true);
         int updatedAppearances = existingMatchPerformanceInCouchbase.getAppearances() + 10;
         MatchPerformance incomingMatchPerformance = ImmutableMatchPerformance.builder()
-                .from(getMatchPerformanceDataStub(null, false))
+                .from(getMatchPerformanceDataStub(existingMatchPerformanceId, false))
                 .appearances(updatedAppearances)
                 .build();
 


### PR DESCRIPTION
In this PR, implemented the following:
- Entity model for the match performance entity
- Endpoint resource (with RAML documentation) to perform basic CRUD operations on it
- Custom endpoint to fetch match performance data when given a player ID and a competition identifier with the following logic. Logic to accommodate scenarios when no `competitionId` is provided will be handled in future tickets.