### PR TITLE
Pass extra context to query function through meta option

### DIFF
--- a/dashboard-ui/src/clients/AuthClient.js
+++ b/dashboard-ui/src/clients/AuthClient.js
@@ -26,8 +26,7 @@ export const authenticateUser = async ({ username, password }) => {
  * @param {string} queryData.queryKey
  * @returns user data containing userId, email, firstName, lastName and encrypted password
  */
-export const fetchUser = async ({ queryKey }) => {
-    const [_key, { authData }] = queryKey;
+export const fetchUser = async ({ meta: { authData } }) => {
     const res = await fetchDataFromEndpoint(`users/${authData.userId}`, 'GET', {
         Authorization: `BEARER ${authData.id}`
     });

--- a/dashboard-ui/src/clients/DashboardClient.js
+++ b/dashboard-ui/src/clients/DashboardClient.js
@@ -1,7 +1,6 @@
 import fetchDataFromEndpoint from './utils';
 
-export const fetchSquadHubData = async ({ queryKey }) => {
-    const [_key, { authData }] = queryKey;
+export const fetchSquadHubData = async ({ meta: { authData } }) => {
     // TODO: hard-coding the clubId until we can create a club from the UI
     const clubId = 'b60a9dc6-81a3-4ca1-b24b-088220fdca59';
     const res = await fetchDataFromEndpoint(`club/${clubId}/squadPlayers`, 'GET', {
@@ -10,14 +9,14 @@ export const fetchSquadHubData = async ({ queryKey }) => {
     return await res.json();
 };
 
-export const fetchPlayerData = async ({ queryKey }) => {
-    const [_key, { playerId, authData }] = queryKey;
+export const fetchPlayerData = async ({ queryKey, meta: { authData } }) => {
+    const playerId = queryKey[1];
     const res = await fetchDataFromEndpoint(`players/${playerId}`, 'GET', { Authorization: `BEARER ${authData.id}` });
     return await res.json();
 };
 
-export const fetchPlayerPerformanceData = async ({ queryKey }) => {
-    const [_key, { playerId, authData }] = queryKey;
+export const fetchPlayerPerformanceData = async ({ queryKey, meta: { authData } }) => {
+    const playerId = queryKey[1];
     const competitionId = '8c853fa8-e4ab-47a5-98c2-fe01a15c29d2';
     const res = await fetchDataFromEndpoint(
         `match-performance/lookup/${playerId}?competitionId=${competitionId}`,

--- a/dashboard-ui/src/hooks/usePlayerData.js
+++ b/dashboard-ui/src/hooks/usePlayerData.js
@@ -7,8 +7,9 @@ export default function(queryKey, playerId) {
     const { authData } = useUserAuth();
 
     const { isLoading, isIdle, data: playerData } = useQuery(
-        [queryKey, { playerId, authData }],
+        [queryKey, playerId],
         fetchPlayerData, {
+            meta: { authData },
             // don't run the query if playerId value is not a valid value
             enabled: playerId !== -1
         });

--- a/dashboard-ui/src/hooks/usePlayerPerfData.js
+++ b/dashboard-ui/src/hooks/usePlayerPerfData.js
@@ -4,10 +4,7 @@ import { fetchPlayerPerformanceData } from '../clients/DashboardClient';
 import { useUserAuth } from '../context/authProvider';
 import { queryKeys } from '../utils';
 
-export default function(playerId) {
+export default function (playerId) {
     const { authData } = useUserAuth();
-    return useQuery(
-        [queryKeys.PLAYER_PERFORMANCE_DATA, { authData, playerId }],
-        fetchPlayerPerformanceData
-    );
+    return useQuery([queryKeys.PLAYER_PERFORMANCE_DATA, playerId], fetchPlayerPerformanceData, { meta: { authData } });
 }

--- a/dashboard-ui/src/hooks/useSquadHubData.js
+++ b/dashboard-ui/src/hooks/useSquadHubData.js
@@ -8,14 +8,12 @@ export default function() {
     const queryClient = useQueryClient();
     const { authData } = useUserAuth();
 
-    const { isLoading, data: squadPlayersData } = useQuery(
-        [queryKeys.SQUAD_DATA, { authData }],
-        fetchSquadHubData, {
-            initialData: () => queryClient.getQueryData(queryKeys.SQUAD_DATA),
-            staleTime: 10 * 1000,
-            initialDataUpdatedAt: queryClient.getQueryState(queryKeys.SQUAD_DATA)?.dataUpdatedAt
-        }
-    );
+    const { isLoading, data: squadPlayersData } = useQuery(queryKeys.SQUAD_DATA, fetchSquadHubData, {
+        meta: { authData },
+        initialData: () => queryClient.getQueryData(queryKeys.SQUAD_DATA),
+        staleTime: 10 * 1000,
+        initialDataUpdatedAt: queryClient.getQueryState(queryKeys.SQUAD_DATA)?.dataUpdatedAt
+    });
 
     return {
         isLoading,

--- a/dashboard-ui/src/hooks/useUserData.js
+++ b/dashboard-ui/src/hooks/useUserData.js
@@ -3,23 +3,22 @@ import { fetchUser } from '../clients/AuthClient';
 import { useUserAuth } from '../context/authProvider';
 import { queryKeys } from '../utils';
 
-export default function() {
+export default function () {
     const { authData, logOut } = useUserAuth();
 
-    const { isLoading, isSuccess, data } = useQuery(
-        [queryKeys.USER_DATA, { authData }],
-        fetchUser, {
-            retry: 0,
-            staleTime: 1000 * 60 * 60 * 8,
-            // don't run the query if authToken is not valid
-            enabled: !!authData,
-            onError: (err) => {
-                if (err.name === 'Unauthorized Error') {
-                    logOut();
-                }
+    const { isLoading, isSuccess, data } = useQuery(queryKeys.USER_DATA, fetchUser, {
+        meta: { authData },
+        retry: 0,
+        staleTime: 1000 * 60 * 60 * 8,
+        // don't run the query if authToken is not valid
+        enabled: !!authData,
+        onError: err => {
+            if (err) {
+                logOut();
             }
         }
-    );
+    });
+
     return {
         isLoading,
         isLoggedIn: isSuccess && data,


### PR DESCRIPTION
Previously, the `authData` was being passed to the query function through the `queryKey` param in the `useQuery` function. This was complicating the query key ultimately being used as the hash key for the data cache since the entire authData was being serialized along with the intended query key. This is corrected in this PR by passing the authData to the client method through the meta property in the options object passed to the `useQuery` function. 