### PR TITLE
Convert HomePageView into ClubPageView

### DIFF
--- a/dashboard-ui/public/mockServiceWorker.js
+++ b/dashboard-ui/public/mockServiceWorker.js
@@ -1,0 +1,338 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker (0.35.0).
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ * - Please do NOT serve this file on production.
+ */
+
+const INTEGRITY_CHECKSUM = 'f0a916b13c8acc2b526a03a6d26df85f'
+const bypassHeaderName = 'x-msw-bypass'
+const activeClientIds = new Set()
+
+self.addEventListener('install', function () {
+  return self.skipWaiting()
+})
+
+self.addEventListener('activate', async function (event) {
+  return self.clients.claim()
+})
+
+self.addEventListener('message', async function (event) {
+  const clientId = event.source.id
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll()
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: INTEGRITY_CHECKSUM,
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: true,
+      })
+      break
+    }
+
+    case 'MOCK_DEACTIVATE': {
+      activeClientIds.delete(clientId)
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+// Resolve the "master" client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMasterClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (client.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll()
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+async function handleRequest(event, requestId) {
+  const client = await resolveMasterClient(event)
+  const response = await getResponse(event, client, requestId)
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    ;(async function () {
+      const clonedResponse = response.clone()
+      sendToClient(client, {
+        type: 'RESPONSE',
+        payload: {
+          requestId,
+          type: clonedResponse.type,
+          ok: clonedResponse.ok,
+          status: clonedResponse.status,
+          statusText: clonedResponse.statusText,
+          body:
+            clonedResponse.body === null ? null : await clonedResponse.text(),
+          headers: serializeHeaders(clonedResponse.headers),
+          redirected: clonedResponse.redirected,
+        },
+      })
+    })()
+  }
+
+  return response
+}
+
+async function getResponse(event, client, requestId) {
+  const { request } = event
+  const requestClone = request.clone()
+  const getOriginalResponse = () => fetch(requestClone)
+
+  // Bypass mocking when the request client is not active.
+  if (!client) {
+    return getOriginalResponse()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return await getOriginalResponse()
+  }
+
+  // Bypass requests with the explicit bypass header
+  if (requestClone.headers.get(bypassHeaderName) === 'true') {
+    const cleanRequestHeaders = serializeHeaders(requestClone.headers)
+
+    // Remove the bypass header to comply with the CORS preflight check.
+    delete cleanRequestHeaders[bypassHeaderName]
+
+    const originalRequest = new Request(requestClone, {
+      headers: new Headers(cleanRequestHeaders),
+    })
+
+    return fetch(originalRequest)
+  }
+
+  // Send the request to the client-side MSW.
+  const reqHeaders = serializeHeaders(request.headers)
+  const body = await request.text()
+
+  const clientMessage = await sendToClient(client, {
+    type: 'REQUEST',
+    payload: {
+      id: requestId,
+      url: request.url,
+      method: request.method,
+      headers: reqHeaders,
+      cache: request.cache,
+      mode: request.mode,
+      credentials: request.credentials,
+      destination: request.destination,
+      integrity: request.integrity,
+      redirect: request.redirect,
+      referrer: request.referrer,
+      referrerPolicy: request.referrerPolicy,
+      body,
+      bodyUsed: request.bodyUsed,
+      keepalive: request.keepalive,
+    },
+  })
+
+  switch (clientMessage.type) {
+    case 'MOCK_SUCCESS': {
+      return delayPromise(
+        () => respondWithMock(clientMessage),
+        clientMessage.payload.delay,
+      )
+    }
+
+    case 'MOCK_NOT_FOUND': {
+      return getOriginalResponse()
+    }
+
+    case 'NETWORK_ERROR': {
+      const { name, message } = clientMessage.payload
+      const networkError = new Error(message)
+      networkError.name = name
+
+      // Rejecting a request Promise emulates a network error.
+      throw networkError
+    }
+
+    case 'INTERNAL_ERROR': {
+      const parsedBody = JSON.parse(clientMessage.payload.body)
+
+      console.error(
+        `\
+[MSW] Uncaught exception in the request handler for "%s %s":
+
+${parsedBody.location}
+
+This exception has been gracefully handled as a 500 response, however, it's strongly recommended to resolve this error, as it indicates a mistake in your code. If you wish to mock an error response, please see this guide: https://mswjs.io/docs/recipes/mocking-error-responses\
+`,
+        request.method,
+        request.url,
+      )
+
+      return respondWithMock(clientMessage)
+    }
+  }
+
+  return getOriginalResponse()
+}
+
+self.addEventListener('fetch', function (event) {
+  const { request } = event
+  const accept = request.headers.get('accept') || ''
+
+  // Bypass server-sent events.
+  if (accept.includes('text/event-stream')) {
+    return
+  }
+
+  // Bypass navigation requests.
+  if (request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = uuidv4()
+
+  return event.respondWith(
+    handleRequest(event, requestId).catch((error) => {
+      if (error.name === 'NetworkError') {
+        console.warn(
+          '[MSW] Successfully emulated a network error for the "%s %s" request.',
+          request.method,
+          request.url,
+        )
+        return
+      }
+
+      // At this point, any exception indicates an issue with the original request/response.
+      console.error(
+        `\
+[MSW] Caught an exception from the "%s %s" request (%s). This is probably not a problem with Mock Service Worker. There is likely an additional logging output above.`,
+        request.method,
+        request.url,
+        `${error.name}: ${error.message}`,
+      )
+    }),
+  )
+})
+
+function serializeHeaders(headers) {
+  const reqHeaders = {}
+  headers.forEach((value, name) => {
+    reqHeaders[name] = reqHeaders[name]
+      ? [].concat(reqHeaders[name]).concat(value)
+      : value
+  })
+  return reqHeaders
+}
+
+function sendToClient(client, message) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(JSON.stringify(message), [channel.port2])
+  })
+}
+
+function delayPromise(cb, duration) {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(cb()), duration)
+  })
+}
+
+function respondWithMock(clientMessage) {
+  return new Response(clientMessage.payload.body, {
+    ...clientMessage.payload,
+    headers: clientMessage.payload.headers,
+  })
+}
+
+function uuidv4() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const r = (Math.random() * 16) | 0
+    const v = c == 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+}

--- a/dashboard-ui/src/App.js
+++ b/dashboard-ui/src/App.js
@@ -9,6 +9,7 @@ import Layout from './Layout';
 import { useThemePreference } from './context/themePreferenceProvider';
 import { ChartOptionsProvider } from './context/chartOptionsProvider';
 import { AuthContextProvider } from './context/authProvider';
+import { ClubContextProvider } from './context/clubProvider';
 
 function App() {
     const queryClient = new QueryClient();
@@ -29,7 +30,9 @@ function App() {
                 <ThemeProvider theme={theme}>
                     <ChartOptionsProvider>
                         <AuthContextProvider>
-                            <Layout />
+                            <ClubContextProvider>
+                                <Layout />
+                            </ClubContextProvider>
                         </AuthContextProvider>
                     </ChartOptionsProvider>
                 </ThemeProvider>

--- a/dashboard-ui/src/Layout.js
+++ b/dashboard-ui/src/Layout.js
@@ -11,6 +11,7 @@ import Sidebar from './widgets/Sidebar';
 import UserAuth from './pages/UserAuth';
 import routingData from './routing/routingData';
 import useUserData from './hooks/useUserData';
+import PrivateRoute from './routing/PrivateRoute';
 
 const useStyles = makeStyles(theme => ({
     root: {
@@ -80,14 +81,18 @@ const AppContainer = ({ classes }) => {
             <main className={classes.content}>
                 <div className={classes.view}>
                     <Switch>
-                        {routingData.map((sidebarItemData, _idx) => (
-                            <Route
-                                exact={sidebarItemData.isExact}
-                                key={_idx}
-                                path={sidebarItemData.routePath}
-                                component={sidebarItemData.component}
-                            />
-                        ))}
+                        {routingData.map((sidebarItemData, _idx) => {
+                            return sidebarItemData.disabledPaths ? (
+                                <PrivateRoute path={sidebarItemData.routePath} component={sidebarItemData.component} />
+                            ) : (
+                                <Route
+                                    exact={sidebarItemData.isExact}
+                                    key={_idx}
+                                    path={sidebarItemData.routePath}
+                                    component={sidebarItemData.component}
+                                />
+                            );
+                        })}
                     </Switch>
                 </div>
             </main>

--- a/dashboard-ui/src/Layout.js
+++ b/dashboard-ui/src/Layout.js
@@ -9,7 +9,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import AppBarMenu from './components/AppBarMenu';
 import Sidebar from './widgets/Sidebar';
 import UserAuth from './pages/UserAuth';
-import routingData from './routingData';
+import routingData from './routing/routingData';
 import useUserData from './hooks/useUserData';
 
 const useStyles = makeStyles(theme => ({

--- a/dashboard-ui/src/clients/ClubClient.js
+++ b/dashboard-ui/src/clients/ClubClient.js
@@ -8,6 +8,12 @@ export const fetchAllClubs = async ({ meta: { authData } }) => {
     return await res.json();
 };
 
+export const fetchClub = async ({ queryKey, meta: { authData }}) => {
+    const clubId = queryKey[1];
+    const res = await fetchDataFromEndpoint(`club/${clubId}`, 'GET', { Authorization: `BEARER ${authData.id}`});
+    return await res.json();
+};
+
 export const createNewClub = async ({ newClubData, authToken }) => {
     const res = await fetchDataFromEndpoint('club', 'POST', { Authorization: `BEARER ${authToken}` }, newClubData);
     if (res.ok) {

--- a/dashboard-ui/src/components/BoardObjective.js
+++ b/dashboard-ui/src/components/BoardObjective.js
@@ -1,0 +1,34 @@
+import PropTypes from 'prop-types';
+
+import ListItem from '@material-ui/core/ListItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import Checkbox from '@material-ui/core/Checkbox';
+import Typography from '@material-ui/core/Typography';
+
+export default function BoardObjective({ objective, hasDivider, handleClickFn }) {
+    const objectiveTitle = (
+        <Typography variant='h6' style={{ textDecoration: objective.isCompleted && 'line-through' }}>
+            {objective.title}
+        </Typography>
+    );
+    return (
+        <ListItem button divider={hasDivider} onClick={handleClickFn}>
+            <ListItemIcon>
+                <Checkbox edge='start' checked={objective.isCompleted} />
+            </ListItemIcon>
+            <ListItemText primary={objectiveTitle} secondary={!objective.isCompleted && objective.description}/>
+        </ListItem>
+    );
+}
+
+BoardObjective.propTypes = {
+    objective: PropTypes.shape({
+        id: PropTypes.string, // TODO: update the type for this prop when finalized on server
+        title: PropTypes.string,
+        description: PropTypes.string,
+        isCompleted: PropTypes.bool
+    }),
+    hasDivider: PropTypes.bool,
+    handleClickFn: PropTypes.func
+};

--- a/dashboard-ui/src/components/EnhancedTableHeader.js
+++ b/dashboard-ui/src/components/EnhancedTableHeader.js
@@ -50,7 +50,7 @@ export default function EnhancedTableHeader({ headerCells, order, orderBy, onReq
                         <StyledTableCell
                             key={ headerCell.id }
                             align={ headerCell.alignment }
-                            padding='default'
+                            padding='normal'
                             sortDirection={ orderBy === headerCell.id ? order : false }
                         >
                             <StyledTableSortLabel

--- a/dashboard-ui/src/context/clubProvider.js
+++ b/dashboard-ui/src/context/clubProvider.js
@@ -1,0 +1,34 @@
+import PropTypes from 'prop-types';
+import { createContext, useContext, useState } from 'react';
+
+const ClubContext = createContext();
+
+function ClubContextProvider({ children }) {
+    const [currentClubId, setCurrentClubId] = useState();
+    const value = {
+        currentClubId,
+        setCurrentClubId
+    };
+
+    return (
+        <ClubContext.Provider value={value}>
+            {children}
+        </ClubContext.Provider>
+    );
+}
+
+ClubContextProvider.propTypes = {
+    children: PropTypes.node
+};
+
+function useCurrentClub() {
+    const currentClubContext = useContext(ClubContext);
+
+    if (currentClubContext === undefined) {
+        throw new Error('useCurrentClub must be used inside ClubContextProvider');
+    }
+
+    return currentClubContext;
+}
+
+export { useCurrentClub, ClubContextProvider };

--- a/dashboard-ui/src/hooks/useClubData.js
+++ b/dashboard-ui/src/hooks/useClubData.js
@@ -1,9 +1,9 @@
 import { useQuery } from 'react-query';
-import { fetchAllClubs } from '../clients/ClubClient';
+import { fetchAllClubs, fetchClub } from '../clients/ClubClient';
 import { useUserAuth } from '../context/authProvider';
 import { queryKeys } from '../utils';
 
-export default function () {
+export function useAllClubData() {
     const { authData } = useUserAuth();
 
     const { isLoading, data: allClubsData } = useQuery(queryKeys.ALL_CLUBS, fetchAllClubs, { meta: { authData }});
@@ -11,5 +11,15 @@ export default function () {
     return {
         isLoading,
         data: isLoading ? {} : allClubsData
+    };
+}
+
+export function useClubData(clubId) {
+    const { authData } = useUserAuth();
+    const { isLoading, data: clubData } = useQuery(['club', clubId], fetchClub, { meta: { authData }});
+
+    return {
+        isLoading,
+        data: isLoading ? {} : clubData
     };
 }

--- a/dashboard-ui/src/index.js
+++ b/dashboard-ui/src/index.js
@@ -2,6 +2,11 @@ import { StrictMode } from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 import { ThemePreferenceProvider } from './context/themePreferenceProvider';
+import { worker } from './mocks/browser';
+
+if (process.env.NODE_ENV === 'development'){
+    worker.start();
+}
 
 ReactDOM.render(
     <StrictMode>

--- a/dashboard-ui/src/mocks/browser.js
+++ b/dashboard-ui/src/mocks/browser.js
@@ -1,0 +1,5 @@
+import { setupWorker } from 'msw';
+import { getClubHandlers, getUserHandlers } from './handlers';
+
+const handlers = [ ...getUserHandlers(), ...getClubHandlers()];
+export const worker = setupWorker(...handlers);

--- a/dashboard-ui/src/mocks/handlers.js
+++ b/dashboard-ui/src/mocks/handlers.js
@@ -47,6 +47,9 @@ export const getClubHandlers = (baseUrl = '*', clubIdFragment = ':clubId') => {
         }),
         rest.post(`${baseUrl}/club`, (req, res, ctx) => {
             return res(ctx.status(201), ctx.json({ id: 'new-club-id', ...req.body }));
+        }),
+        rest.get(`${baseUrl}/club/${clubIdFragment}/squadPlayers`, (req, res, ctx) => {
+            return res(ctx.status(200), ctx.json([]));
         })
     ];
 };

--- a/dashboard-ui/src/mocks/server.js
+++ b/dashboard-ui/src/mocks/server.js
@@ -1,10 +1,8 @@
 import { setupServer } from 'msw/node';
+
 import { getUserHandlers, getClubHandlers } from './handlers';
 
-export const mockAuthData = {
-    id: 'fakeAuthToken',
-    userId: 'fakeUserId'
-};
+const baseUrl = 'http://localhost' + `${process.env.REACT_APP_SERVER_ENDPOINT.replace(/\/$/, '')}`;
 
-const handlers = [ ...getUserHandlers(mockAuthData.userId), ...getClubHandlers()];
+const handlers = [...getUserHandlers(baseUrl, 'fakeUserId', true), ...getClubHandlers(baseUrl, 'fakeClubId')];
 export const server = setupServer(...handlers);

--- a/dashboard-ui/src/pages/Club.js
+++ b/dashboard-ui/src/pages/Club.js
@@ -5,6 +5,7 @@ import { makeStyles } from '@material-ui/core/styles';
 
 import { useClubData } from '../hooks/useClubData';
 import ClubPageView from '../views/ClubPageView';
+import { useCurrentClub } from '../context/clubProvider';
 
 const useStyles = makeStyles({
     loadingCircle: {
@@ -17,10 +18,17 @@ const useStyles = makeStyles({
 
 export default function Club() {
     const classes = useStyles();
+    const { currentClubId, setCurrentClubId } = useCurrentClub();
     const { clubId } = useParams();
     const { isLoading, data: clubData } = useClubData(clubId);
+
     if (isLoading) {
         return <CircularProgress className={classes.loadingCircle} />;
     }
+
+    if(clubData && clubData.id !== currentClubId) {
+        setCurrentClubId(clubData.id);
+    }
+
     return <ClubPageView club={clubData} />;
 }

--- a/dashboard-ui/src/pages/Club.js
+++ b/dashboard-ui/src/pages/Club.js
@@ -1,7 +1,26 @@
+import { useParams } from 'react-router-dom';
+
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { makeStyles } from '@material-ui/core/styles';
+
+import { useClubData } from '../hooks/useClubData';
 import ClubPageView from '../views/ClubPageView';
 
-const Club = () => {
-    return <ClubPageView />;
-};
+const useStyles = makeStyles({
+    loadingCircle: {
+        width: '200px !important',
+        height: '200px !important',
+        alignSelf: 'center',
+        margin: '25vh'
+    }
+});
 
-export default Club;
+export default function Club() {
+    const classes = useStyles();
+    const { clubId } = useParams();
+    const { isLoading, data: clubData } = useClubData(clubId);
+    if (isLoading) {
+        return <CircularProgress className={classes.loadingCircle} />;
+    }
+    return <ClubPageView club={clubData} />;
+}

--- a/dashboard-ui/src/pages/Home.js
+++ b/dashboard-ui/src/pages/Home.js
@@ -4,7 +4,8 @@ import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/styles';
 
 import useUserData from '../hooks/useUserData';
-import useClubData from '../hooks/useClubData';
+import { useAllClubData } from '../hooks/useClubData';
+
 import HomePageView from '../views/HomePageView';
 import useAddNewClub from '../hooks/useAddNewClub';
 import AddClub from '../widgets/AddClub';
@@ -44,7 +45,7 @@ const HomeContainer = () => {
     const { addNewClubAction } = useAddNewClub();
     const addClubWidget = <AddClub addClubAction={addNewClubAction} />;
 
-    const { isLoading, data: allClubsData } = useClubData();
+    const { isLoading, data: allClubsData } = useAllClubData();
     if (isLoading) {
         return <CircularProgress className={classes.loadingCircle} />;
     }

--- a/dashboard-ui/src/routing/PrivateRoute.js
+++ b/dashboard-ui/src/routing/PrivateRoute.js
@@ -1,0 +1,25 @@
+import { Route, Redirect } from 'react-router-dom';
+import PropTypes from 'prop-types';
+
+import { useCurrentClub } from '../context/clubProvider';
+
+export default function PrivateRoute({ component: Component, ...rest }) {
+    // TODO: pass a access flag instead of tight coupling with club page visibility logic
+    const { currentClubId } = useCurrentClub();
+    return (
+        <Route
+            {...rest}
+            render={() => {
+                if (currentClubId) {
+                    return <Component />;
+                }
+
+                return <Redirect to='/' />;
+            }}
+        />
+    );
+}
+
+PrivateRoute.propTypes = {
+    component: PropTypes.node
+};

--- a/dashboard-ui/src/routing/routingData.js
+++ b/dashboard-ui/src/routing/routingData.js
@@ -1,10 +1,10 @@
 import HomeIcon from '@material-ui/icons/Home';
 import GroupIcon from '@material-ui/icons/Group';
 
-import SquadHub from './pages/SquadHub';
-import Home from './pages/Home';
-import Player from './pages/Player';
-import Club from './pages/Club';
+import SquadHub from '../pages/SquadHub';
+import Home from '../pages/Home';
+import Player from '../pages/Player';
+import Club from '../pages/Club';
 
 const routingData = [{
     text: 'Home',

--- a/dashboard-ui/src/setupTests.js
+++ b/dashboard-ui/src/setupTests.js
@@ -3,11 +3,9 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/extend-expect';
-import { server, mockAuthData } from './mocks/server';
-import { AUTH_DATA_LS_KEY } from './utils';
+import { server } from './mocks/server';
 
 beforeAll(() => {
-    localStorage.setItem(AUTH_DATA_LS_KEY, JSON.stringify(mockAuthData));
     server.listen({
         onUnhandledRequest: 'warn'
     });

--- a/dashboard-ui/src/stories/BoardObjective.stories.js
+++ b/dashboard-ui/src/stories/BoardObjective.stories.js
@@ -1,0 +1,33 @@
+import { action } from '@storybook/addon-actions';
+
+import BoardObjective from '../components/BoardObjective';
+import { getBoardObjectives } from './utils/storyDataGenerators';
+
+export default {
+    component: BoardObjective,
+    title: 'Components/ClubPageView/BoardObjective'
+};
+
+const Template = args => <BoardObjective {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+    objective: getBoardObjectives(1)[0],
+    hasDivider: false,
+    handleClickFn: action('Board Objective was clicked!')
+};
+
+export const Completed = Template.bind({});
+Completed.args = {
+    ...Default.args,
+    objective: {
+        ...Default.args.objective,
+        isCompleted: true
+    }
+};
+
+export const WithDivider = Template.bind({});
+WithDivider.args = {
+    ...Default.args,
+    hasDivider: true
+};

--- a/dashboard-ui/src/stories/BoardObjectives.stories.js
+++ b/dashboard-ui/src/stories/BoardObjectives.stories.js
@@ -1,0 +1,24 @@
+import BoardObjectives from '../widgets/BoardObjectives';
+import { getBoardObjectives } from './utils/storyDataGenerators';
+
+export default {
+    component: BoardObjectives,
+    title: 'Widgets/ClubPageView/BoardObjectives'
+};
+
+const Template = args => <BoardObjectives {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+    objectives: getBoardObjectives(4)
+};
+
+export const FullObjectives = Template.bind({});
+FullObjectives.args = {
+    objectives: getBoardObjectives(5)
+};
+
+export const NoObjectives = Template.bind({});
+NoObjectives.args = {
+    objectives: []
+};

--- a/dashboard-ui/src/stories/ClubPageView.stories.js
+++ b/dashboard-ui/src/stories/ClubPageView.stories.js
@@ -1,5 +1,7 @@
 import ClubPageView from '../views/ClubPageView';
 
+import { getClubsData } from './utils/storyDataGenerators';
+
 export default {
     component: ClubPageView,
     title: 'Views/ClubPageView',
@@ -16,3 +18,6 @@ export default {
 
 const Template = args => <ClubPageView {...args} />;
 export const Default = Template.bind({});
+Default.args = {
+    club: getClubsData(1)[0]
+};

--- a/dashboard-ui/src/stories/utils/storyDataGenerators.js
+++ b/dashboard-ui/src/stories/utils/storyDataGenerators.js
@@ -284,3 +284,11 @@ export const getClubsData = (numClubs) => {
         expenditure: getRandomNumberInRange(500000, 10000000),
     }));
 };
+
+export const getBoardObjectives = (numObjectives = 5) =>
+    [...Array(numObjectives)].map((_0, idx) => ({
+        id: 'fake id ' + idx,
+        title: faker.lorem.sentence(),
+        description: faker.lorem.paragraph(),
+        isCompleted: false
+    }));

--- a/dashboard-ui/src/views/ClubPageView.js
+++ b/dashboard-ui/src/views/ClubPageView.js
@@ -66,24 +66,23 @@ const ClubFinancesChart = ({ income, expenditure }) => {
     const months = ['Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
     // TODO: build full array once income and expenditure history (month-wise) tracking is implemented
-    let profit = [ ...Array(months.length).fill(0) ];
-    profit[0] = income - expenditure;
+    const profit = [ (income - expenditure), ...Array(months.length).fill(0) ];
 
     const clubFinancesData = {
         cardTitle: 'Club Finances',
-        chartData: [{ name: 'Profit', data: profit }],
-        dataTransformer: x => x,
+        chartData: [
+            { name: 'Profit', data: [...Array(months.length)].map((_, idx) => ({ x: months[idx], y: profit[idx] })) }
+        ],
         chartOptions: {
-            stroke: { width: 2, curve: 'straight' },
-            plotOptions: { bar: { columnWidth: '15%' } },
+            stroke: { curve: 'straight' },
             dataLabels: { enabled: false },
-            legend: { show: false },
+            fill: { opacity: 0.5 },
             xaxis: {
-                title: { text: 'Months', style: { fontFamily: 'Roboto' } },
-                categories: months
+                title: { text: 'Months' },
             }
         },
-        chartType: 'bar'
+        dataTransformer: x => x,
+        chartType: 'area'
     };
 
     return (

--- a/dashboard-ui/src/views/ClubPageView.js
+++ b/dashboard-ui/src/views/ClubPageView.js
@@ -8,10 +8,10 @@ import faker from 'faker';
 import Grid from '@material-ui/core/Grid';
 import Card from '@material-ui/core/Card';
 import CardHeader from '@material-ui/core/CardHeader';
+import CardContent from '@material-ui/core/CardContent';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
-import Divider from '@material-ui/core/Divider';
 import Typography from '@material-ui/core/Typography';
 
 import LeagueTable from '../widgets/LeagueTable';
@@ -128,21 +128,20 @@ const BoardObjectives = () => {
     return (
         <Card>
             <CardHeader title='Board Objectives' style={{ paddingBottom: 0 }} />
-            <List>
-                {boardObjectives.map((objective, idx) => {
-                    return (
-                        <>
-                            <ListItem key={idx}>
+            <CardContent style={{ paddingTop: 0, paddingBottom: 0 }}>
+                <List>
+                    {boardObjectives.map((objective, idx) => {
+                        return (
+                            <ListItem key={idx} disableGutters divider={idx < boardObjectives.length - 1}>
                                 <ListItemText
                                     primary={<Typography variant='h6'>{objective.title}</Typography>}
                                     secondary={objective.description}
                                 />
                             </ListItem>
-                            {idx < boardObjectives.length - 1 && <Divider variant='middle' component='li' />}
-                        </>
-                    );
-                })}
-            </List>
+                        );
+                    })}
+                </List>
+            </CardContent>
         </Card>
     );
 };

--- a/dashboard-ui/src/views/ClubPageView.js
+++ b/dashboard-ui/src/views/ClubPageView.js
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types';
+
 import ReactApexChart from 'react-apexcharts';
 
 // TODO: remove this once the fake data generators are replaced
@@ -18,7 +20,7 @@ import CardWithChart from '../widgets/CardWithChart';
 // TODO: remove this once the fake data generators are replaced
 import { getLeagueTableData, getPlayerProgressionData, MAX_ATTR_VALUE } from '../stories/utils/storyDataGenerators';
 
-export default function ClubPageView() {
+export default function ClubPageView({ club }) {
     return (
         <>
             <Grid container spacing={2}>
@@ -143,4 +145,15 @@ const BoardObjectives = () => {
             </List>
         </Card>
     );
+};
+
+ClubPageView.propTypes = {
+    club: PropTypes.shape({
+        id: PropTypes.string,
+        name: PropTypes.string,
+        transferBudget: PropTypes.number,
+        wageBudget: PropTypes.number,
+        income: PropTypes.number,
+        expenditure: PropTypes.number
+    })
 };

--- a/dashboard-ui/src/views/ClubPageView.js
+++ b/dashboard-ui/src/views/ClubPageView.js
@@ -28,7 +28,7 @@ export default function ClubPageView({ club }) {
                     <LeagueTable metadata={getLeagueTableData(10)} />
                 </Grid>
                 <Grid item xs={8} container direction='column'>
-                    <ClubFinancesChart />
+                    <ClubFinancesChart income={club.income} expenditure={club.expenditure}/>
                     <ClubSuccessChart />
                 </Grid>
             </Grid>
@@ -37,7 +37,7 @@ export default function ClubPageView({ club }) {
                     <BoardObjectives />
                 </Grid>
                 <Grid item xs>
-                    <TransferBudgetChart />
+                    <BudgetBreakdownChart transferBudget={club.transferBudget} wageBudget={club.wageBudget}/>
                 </Grid>
             </Grid>
         </>
@@ -70,11 +70,16 @@ const ClubSuccessChart = () => {
     );
 };
 
-const ClubFinancesChart = () => {
-    // TODO: remove this fake data with the real thing
+const ClubFinancesChart = ({ income, expenditure }) => {
+    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+    // TODO: build full array once income and expenditure history (month-wise) tracking is implemented
+    let profit = [ ...Array(months.length).fill(0) ];
+    profit[0] = income - expenditure;
+
     const clubFinancesData = {
         cardTitle: 'Club Finances',
-        chartData: getPlayerProgressionData(1, 'Income', MAX_ATTR_VALUE),
+        chartData: [{ name: 'Profit', data: profit }],
         dataTransformer: x => x,
         chartOptions: {
             stroke: { width: 2, curve: 'straight' },
@@ -83,7 +88,7 @@ const ClubFinancesChart = () => {
             legend: { show: false },
             xaxis: {
                 title: { text: 'Months', style: { fontFamily: 'Roboto' } },
-                categories: [1, 2, 3, 4, 5, 6]
+                categories: months
             }
         },
         chartType: 'bar'
@@ -97,15 +102,18 @@ const ClubFinancesChart = () => {
         </Grid>
     );
 };
+ClubFinancesChart.propTypes = {
+    income: PropTypes.number,
+    expenditure: PropTypes.number
+};
 
-const TransferBudgetChart = () => {
-    // TODO: remove this fake data with the real thing
+const BudgetBreakdownChart = ({ transferBudget, wageBudget }) => {
     const transferBudgetData = {
         cardTitle: 'Budget for EY 2021',
-        chartData: [25, 60, 15],
+        chartData: [transferBudget, wageBudget],
         dataTransformer: x => x,
         chartOptions: {
-            labels: ['Scouting', 'Transfers', 'Youth Academy']
+            labels: ['Transfers', 'Wages']
         },
         chartType: 'donut'
     };
@@ -117,6 +125,10 @@ const TransferBudgetChart = () => {
             </CardWithChart>
         </Grid>
     );
+};
+BudgetBreakdownChart.propTypes = {
+    transferBudget: PropTypes.number,
+    wageBudget: PropTypes.number
 };
 
 const BoardObjectives = () => {

--- a/dashboard-ui/src/views/ClubPageView.js
+++ b/dashboard-ui/src/views/ClubPageView.js
@@ -1,21 +1,11 @@
 import PropTypes from 'prop-types';
-
 import ReactApexChart from 'react-apexcharts';
 
-// TODO: remove this once the fake data generators are replaced
-import faker from 'faker';
-
 import Grid from '@material-ui/core/Grid';
-import Card from '@material-ui/core/Card';
-import CardHeader from '@material-ui/core/CardHeader';
-import CardContent from '@material-ui/core/CardContent';
-import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
-import ListItemText from '@material-ui/core/ListItemText';
-import Typography from '@material-ui/core/Typography';
 
 import LeagueTable from '../widgets/LeagueTable';
 import CardWithChart from '../widgets/CardWithChart';
+import BoardObjectives from '../widgets/BoardObjectives';
 
 // TODO: remove this once the fake data generators are replaced
 import { getLeagueTableData, getPlayerProgressionData, MAX_ATTR_VALUE } from '../stories/utils/storyDataGenerators';
@@ -34,7 +24,9 @@ export default function ClubPageView({ club }) {
             </Grid>
             <Grid container spacing={2}>
                 <Grid item xs>
-                    <BoardObjectives />
+                    {/* TODO: move this into a container function where the useMutation hook and other business logic
+                     can be housed. Then pass in actual objectives instead of the default empty list here. */}
+                    <BoardObjectives objectives={[]} />
                 </Grid>
                 <Grid item xs>
                     <BudgetBreakdownChart transferBudget={club.transferBudget} wageBudget={club.wageBudget}/>
@@ -129,33 +121,6 @@ const BudgetBreakdownChart = ({ transferBudget, wageBudget }) => {
 BudgetBreakdownChart.propTypes = {
     transferBudget: PropTypes.number,
     wageBudget: PropTypes.number
-};
-
-const BoardObjectives = () => {
-    // TODO: remove this fake data with the real thing
-    const boardObjectives = [...Array(5)].map(() => ({
-        title: faker.lorem.sentence(),
-        description: faker.lorem.paragraph()
-    }));
-    return (
-        <Card>
-            <CardHeader title='Board Objectives' style={{ paddingBottom: 0 }} />
-            <CardContent style={{ paddingTop: 0, paddingBottom: 0 }}>
-                <List>
-                    {boardObjectives.map((objective, idx) => {
-                        return (
-                            <ListItem key={idx} disableGutters divider={idx < boardObjectives.length - 1}>
-                                <ListItemText
-                                    primary={<Typography variant='h6'>{objective.title}</Typography>}
-                                    secondary={objective.description}
-                                />
-                            </ListItem>
-                        );
-                    })}
-                </List>
-            </CardContent>
-        </Card>
-    );
 };
 
 ClubPageView.propTypes = {

--- a/dashboard-ui/src/widgets/BoardObjectives.js
+++ b/dashboard-ui/src/widgets/BoardObjectives.js
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+
+import Card from '@material-ui/core/Card';
+import CardHeader from '@material-ui/core/CardHeader';
+import CardContent from '@material-ui/core/CardContent';
+import CardActions from '@material-ui/core/CardActions';
+import List from '@material-ui/core/List';
+import Typography from '@material-ui/core/Typography';
+import Divider from '@material-ui/core/Divider';
+import Button from '@material-ui/core/Button';
+
+import BoardObjective from '../components/BoardObjective';
+
+export default function BoardObjectives({ objectives: initialObjectives }) {
+    const [isDirty, setIsDirty] = useState(false);
+    const [objectives, setObjectives] = useState(initialObjectives);
+
+    const completeObjective = objectiveId => {
+        const updatedObjectives = objectives.map(objective => {
+            if (objective.id === objectiveId) {
+                return {
+                    ...objective,
+                    isCompleted: !objective.isCompleted
+                };
+            }
+            return objective;
+        });
+
+        setIsDirty(!_.isEqual(updatedObjectives, initialObjectives));
+        setObjectives(updatedObjectives);
+    };
+
+    const noObjective = (
+        <Typography component='div' variant='h6' align='center' color='textSecondary'>
+            No Board Objectives have been added yet!
+        </Typography>
+    );
+
+    return (
+        <Card>
+            {/* TODO: add icon to represent manager rating */}
+            <CardHeader title='Board Objectives' style={{ paddingBottom: 0 }} />
+            <CardContent style={{ paddingTop: 0, paddingBottom: 0 }}>
+                {objectives.length === 0 && noObjective}
+                <List>
+                    {objectives.map((objective, idx) => {
+                        return (
+                            <BoardObjective
+                                key={objective.id}
+                                objective={objective}
+                                hasDivider={idx < objectives.length - 1}
+                                handleClickFn={() => completeObjective(objective.id)}
+                            />
+                        );
+                    })}
+                </List>
+            </CardContent>
+            {/* TODO: add the ObjectiveForm widget for adding new objectives when the rest of the functionality
+            is ready */}
+            <Divider variant='middle' />
+            <CardActions>
+                <Button color='primary' disabled={objectives.length === 5}>
+                    Add Objective
+                </Button>
+                {/* TODO: update the widget to consume a mutute function which can be used to save changes to
+                the objectives  */}
+                <Button color='primary' disabled={!isDirty}>
+                    Save Changes
+                </Button>
+            </CardActions>
+        </Card>
+    );
+}
+
+BoardObjectives.propTypes = {
+    objectives: PropTypes.arrayOf(BoardObjective.propTypes.objective)
+};

--- a/dashboard-ui/src/widgets/BoardObjectives.test.js
+++ b/dashboard-ui/src/widgets/BoardObjectives.test.js
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Default, NoObjectives, FullObjectives } from '../stories/BoardObjectives.stories';
+
+it('renders successfully', () => {
+    render(<Default {...Default.args} />);
+    const numObjectives = Default.args.objectives.length;
+    const objectiveItemHeadings = screen.getAllByRole('heading');
+    expect(objectiveItemHeadings.length).toEqual(numObjectives);
+
+    // using the checkbox and its checked/unchecked status as a proxy for the objective's complete/incomplete state
+    const incompleteObjectives = screen.getAllByRole('checkbox', { checked: false });
+    expect(incompleteObjectives.length).toEqual(numObjectives);
+});
+
+it('should render Save Changes button as disabled when nothing has changed', () => {
+    render(<Default {...Default.args} />);
+    const saveChangesButton = screen.getByRole('button', { name: 'Save Changes'});
+    expect(saveChangesButton).toBeDisabled();
+});
+
+it('should render Add Objective button as disabled when objectives limit has been reached', () => {
+    render(<FullObjectives {...FullObjectives.args} />);
+    const addObjectiveButton = screen.getByRole('button', { name: 'Add Objective'});
+    expect(addObjectiveButton).toBeDisabled();
+});
+
+it('should render text when no objectives have been added', () => {
+    render(<NoObjectives {...NoObjectives.args} />);
+    expect(screen.getByText('No Board Objectives have been added yet!')).toBeInTheDocument();
+});
+
+it('should mark objective as completed and enable Save Changes button when objective is clicked on', () => {
+    render(<Default {...Default.args} />);
+    const { title: objectiveTitle } = Default.args.objectives[0];
+    const objectiveItemHeading = screen.getByRole('heading', { name: objectiveTitle });
+
+    userEvent.click(objectiveItemHeading);
+
+    // verify that the heading has a strike-through styling and the checkbox is checked
+    expect(screen.getByRole('checkbox', { checked: true })).toBeInTheDocument();
+    expect(objectiveItemHeading).toHaveStyle({ 'text-decoration': 'line-through' });
+
+    // since there is a change in the state of the objectives, the Save Changes button is expected to not be `disabled`
+    const saveChangesButton = screen.getByRole('button', { name: 'Save Changes' });
+    expect(saveChangesButton).not.toBeDisabled();
+});


### PR DESCRIPTION
In this PR, added a client to fetch the current club's information and use that to populate the various charts and widgets on the club's home page. Also, moved the BoardObjectives component into its own widget (with associated story and tests) to allow for more complex behavior. Finally, added the ability to limit the accessibility of certain routes if conditions are not met (redirected to Home page in such cases).