### PR TITLE
Integrate add player form with backend

### DIFF
--- a/dashboard-server/src/main/java/com/footballstatsdashboard/FootballDashboardApplication.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/FootballDashboardApplication.java
@@ -103,7 +103,7 @@ public class FootballDashboardApplication extends Application<FootballDashboardC
 
         // setup resources
         environment.jersey().register(new UserResource(userCouchbaseDAO, authTokenDAO));
-        environment.jersey().register(new PlayerResource(playerService));
+        environment.jersey().register(new PlayerResource(playerService, clubCouchbaseDAO));
         environment.jersey().register(new ClubResource(clubCouchbaseDAO));
         environment.jersey().register(new MatchPerformanceResource(matchPerformanceDAO));
 

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/FootballDashboardApplication.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/FootballDashboardApplication.java
@@ -22,6 +22,7 @@ import com.footballstatsdashboard.resources.ClubResource;
 import com.footballstatsdashboard.resources.MatchPerformanceResource;
 import com.footballstatsdashboard.resources.PlayerResource;
 import com.footballstatsdashboard.resources.UserResource;
+import com.footballstatsdashboard.services.PlayerService;
 import io.dropwizard.Application;
 import io.dropwizard.auth.AuthDynamicFeature;
 import io.dropwizard.auth.AuthValueFactoryProvider;
@@ -96,6 +97,9 @@ public class FootballDashboardApplication extends Application<FootballDashboardC
                 couchbaseClientManager.getBucketContainer(clusterName, bucketName),
                 couchbaseClientManager.getClusterContainer(clusterName),
                 new AuthTokenKeyProvider(), environment.getObjectMapper());
+
+        // setup services
+        PlayerService playerService = new PlayerService(playerCouchbaseDAO);
 
         // setup resources
         environment.jersey().register(new UserResource(userCouchbaseDAO, authTokenDAO));

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/FootballDashboardApplication.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/FootballDashboardApplication.java
@@ -103,7 +103,7 @@ public class FootballDashboardApplication extends Application<FootballDashboardC
 
         // setup resources
         environment.jersey().register(new UserResource(userCouchbaseDAO, authTokenDAO));
-        environment.jersey().register(new PlayerResource(playerCouchbaseDAO));
+        environment.jersey().register(new PlayerResource(playerService));
         environment.jersey().register(new ClubResource(clubCouchbaseDAO));
         environment.jersey().register(new MatchPerformanceResource(matchPerformanceDAO));
 

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/CountryCodeMetadata.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/CountryCodeMetadata.java
@@ -1,0 +1,27 @@
+package com.footballstatsdashboard.api.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+import javax.validation.Valid;
+
+@Value.Immutable
+@JsonSerialize
+@JsonDeserialize(as = ImmutableCountryCodeMetadata.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public interface CountryCodeMetadata {
+
+    /**
+     * country name
+     */
+    @Valid
+    String getCountryName();
+
+    /**
+     * country name
+     */
+    @Valid
+    String getCountryCode();
+}

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/Player.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/Player.java
@@ -52,7 +52,9 @@ public interface Player {
     /**
      * Information about the player's ability, both current and past data
      */
-    @Valid Ability getAbility();
+    @Valid
+    @Nullable
+    Ability getAbility();
 
     /**
      * Information about the player's attributes

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/player/Attribute.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/player/Attribute.java
@@ -50,6 +50,7 @@ public interface Attribute {
      * list of historical values of the attribute corresponding to each past month
      */
     @Valid
+    @Nullable
     @Size(min = 1)
     List<Integer> getHistory();
 }

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/player/Attribute.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/player/Attribute.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
+import javax.annotation.Nullable;
 import javax.validation.Valid;
 import javax.validation.constraints.Size;
 import java.util.List;
@@ -29,12 +30,14 @@ public interface Attribute {
      * category the attribute belongs to
      */
     @Valid
+    @Nullable
     String getCategory();
 
     /**
      * group the attribute belongs to
      */
     @Valid
+    @Nullable
     String getGroup();
 
     /**

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/player/Metadata.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/player/Metadata.java
@@ -1,17 +1,12 @@
 package com.footballstatsdashboard.api.model.player;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import org.immutables.value.Value;
 
 import javax.annotation.Nullable;
 import javax.validation.Valid;
-import java.time.LocalDate;
-import java.time.Period;
 
 /**
  * Represents the metadata for a player
@@ -26,18 +21,7 @@ public interface Metadata {
      * player's full name
      */
     @Valid
-    @Nullable
     String getName();
-
-    /**
-     * player's date of birth
-     */
-    @Valid
-    @Nullable
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    @JsonDeserialize(using = LocalDateDeserializer.class)
-    @JsonSerialize(using = LocalDateSerializer.class)
-    LocalDate getDateOfBirth();
 
     /**
      * player's current club name
@@ -50,14 +34,13 @@ public interface Metadata {
      * player's nationality
      */
     @Valid
-    @Nullable
     String getCountry();
 
     /**
      * url for player's photograph
      */
     @Valid
-    @Nullable
+    @Nullable // TODO: remove nullable when client functionality is implemented for uploading player image
     String getPhoto();
 
     /**
@@ -77,11 +60,6 @@ public interface Metadata {
     /**
      * player's current age in years
      */
-    @Value.Derived
-    default Integer getAge() {
-        if (getDateOfBirth() != null) {
-            return Period.between(getDateOfBirth(), LocalDate.now()).getYears();
-        }
-        return null;
-    }
+    @Valid
+    Integer getAge();
 }

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/player/Metadata.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/player/Metadata.java
@@ -7,6 +7,8 @@ import org.immutables.value.Value;
 
 import javax.annotation.Nullable;
 import javax.validation.Valid;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 
 /**
  * Represents the metadata for a player
@@ -16,6 +18,9 @@ import javax.validation.Valid;
 @JsonDeserialize(as = ImmutableMetadata.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public interface Metadata {
+
+    int MIN_PLAYER_AGE = 15;
+    int MAX_PLAYER_AGE = 50;
 
     /**
      * player's full name
@@ -61,5 +66,7 @@ public interface Metadata {
      * player's current age in years
      */
     @Valid
+    @Min(value = MIN_PLAYER_AGE, message = "Age should not be less than 15")
+    @Max(value = MAX_PLAYER_AGE, message = "Age should not be greater than 50")
     Integer getAge();
 }

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/core/utils/Constants.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/core/utils/Constants.java
@@ -1,5 +1,8 @@
 package com.footballstatsdashboard.core.utils;
 
+import org.apache.commons.lang3.tuple.Pair;
+import java.util.Map;
+
 public final class Constants {
     private Constants() {
         throw new AssertionError("Should not be initialized");
@@ -25,4 +28,33 @@ public final class Constants {
     public static final String MATCH_PERFORMANCE_LOOKUP_PATH = "/lookup" + PLAYER_ID_PATH;
 
     public static final int HASHING_COST = 12;
+
+    public static final Map<String, Pair<String, String>> PLAYER_ATTRIBUTE_CATEGORY_MAP = Map.ofEntries(
+            Map.entry("freekick accuracy", Pair.of("Technical", "Attacking")),
+            Map.entry("penalties", Pair.of("Technical", "Attacking")),
+            Map.entry("crossing", Pair.of("Technical", "Attacking")),
+            Map.entry("long shots", Pair.of("Technical", "Attacking")),
+            Map.entry("finishing", Pair.of("Technical", "Attacking")),
+            Map.entry("volleys", Pair.of("Technical", "Attacking")),
+            Map.entry("ball control", Pair.of("Technical", "Attacking")),
+            Map.entry("dribbling", Pair.of("Technical", "Attacking")),
+            Map.entry("curve", Pair.of("Technical", "Attacking")),
+            Map.entry("short passing", Pair.of("Technical", "Vision")),
+            Map.entry("long Passing", Pair.of("Technical", "Vision")),
+            Map.entry("standing tackle", Pair.of("Technical", "Defending")),
+            Map.entry("sliding tackle", Pair.of("Technical", "Defending")),
+            Map.entry("heading accuracy", Pair.of("Technical", "Aerial")),
+            Map.entry("jumping", Pair.of("Physical", "Aerial")),
+            Map.entry("stamina", Pair.of("Physical", "Defending")),
+            Map.entry("strength", Pair.of("Physical", "Defending")),
+            Map.entry("sprint speed", Pair.of("Physical", "Speed")),
+            Map.entry("acceleration", Pair.of("Physical", "Speed")),
+            Map.entry("agility", Pair.of("Physical", "Speed")),
+            Map.entry("balance", Pair.of("Physical", "Speed")),
+            Map.entry("aggression", Pair.of("Mental", "Attacking")),
+            Map.entry("composure", Pair.of("Mental", "Attacking")),
+            Map.entry("attacking position", Pair.of("Mental", "Attacking")),
+            Map.entry("defensive awareness", Pair.of("Mental", "Defending")),
+            Map.entry("vision", Pair.of("Mental", "Vision"))
+    );
 }

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/core/utils/FixtureLoader.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/core/utils/FixtureLoader.java
@@ -1,4 +1,4 @@
-package com.footballstatsdashboard;
+package com.footballstatsdashboard.core.utils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.util.Resources;
@@ -11,7 +11,7 @@ import java.nio.charset.StandardCharsets;
 
 public final class FixtureLoader {
     private static final Logger LOG = LoggerFactory.getLogger(FixtureLoader.class);
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
 
     public FixtureLoader(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/core/utils/FixtureLoader.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/core/utils/FixtureLoader.java
@@ -1,5 +1,6 @@
 package com.footballstatsdashboard.core.utils;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.util.Resources;
 import org.slf4j.Logger;
@@ -17,8 +18,12 @@ public final class FixtureLoader {
         this.objectMapper = objectMapper;
     }
 
-    public <T> T loadFixture(String filePath, Class<T> entityType) throws IOException, IllegalArgumentException {
-        return this.objectMapper.readValue(getFixtureAsString(filePath), entityType);
+    public <T> T loadFixture(String filePath, Class<T> clazz) throws IOException, IllegalArgumentException {
+        return this.objectMapper.readValue(getFixtureAsString(filePath), clazz);
+    }
+
+    public <T> T loadFixture(String filePath, TypeReference<T> typeRef) throws IOException, IllegalArgumentException {
+        return this.objectMapper.readValue(getFixtureAsString(filePath), typeRef);
     }
 
     private String getFixtureAsString(String fileName) {

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/resources/PlayerResource.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/resources/PlayerResource.java
@@ -24,6 +24,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
+import java.io.IOException;
 import java.net.URI;
 import java.util.UUID;
 
@@ -61,7 +62,7 @@ public class PlayerResource {
     public Response createPlayer(
             @Auth User user,
             @Valid @NotNull Player incomingPlayer,
-            @Context UriInfo uriInfo) {
+            @Context UriInfo uriInfo) throws IOException {
 
         if (LOGGER.isInfoEnabled()) {
             LOGGER.info("createPlayer() request.");

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/resources/PlayerResource.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/resources/PlayerResource.java
@@ -11,6 +11,7 @@ import com.footballstatsdashboard.api.model.player.Metadata;
 import com.footballstatsdashboard.db.CouchbaseDAO;
 import com.footballstatsdashboard.db.key.ResourceKey;
 import io.dropwizard.auth.Auth;
+import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,6 +36,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static com.footballstatsdashboard.core.utils.Constants.PLAYER_ATTRIBUTE_CATEGORY_MAP;
 import static com.footballstatsdashboard.core.utils.Constants.PLAYER_ID;
 import static com.footballstatsdashboard.core.utils.Constants.PLAYER_ID_PATH;
 import static com.footballstatsdashboard.core.utils.Constants.PLAYER_V1_BASE_PATH;
@@ -89,9 +91,16 @@ public class PlayerResource {
                 .build();
 
         List<Attribute> newPlayerAttributes = incomingPlayer.getAttributes().stream()
-                .map(attribute -> ImmutableAttribute.builder().from(attribute)
-                        .history(Collections.singletonList(attribute.getValue()))
-                        .build())
+                .map(attribute -> {
+                    Pair<String, String> categoryAndGroupNamePair =
+                            PLAYER_ATTRIBUTE_CATEGORY_MAP.get(attribute.getName());
+                    return ImmutableAttribute.builder()
+                            .from(attribute)
+                            .category(categoryAndGroupNamePair.getLeft())
+                            .group(categoryAndGroupNamePair.getRight())
+                            .history(Collections.singletonList(attribute.getValue()))
+                            .build();
+                })
                 .collect(Collectors.toList());
 
         LocalDate currentDate = LocalDate.now();

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/resources/PlayerResource.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/resources/PlayerResource.java
@@ -3,6 +3,9 @@ package com.footballstatsdashboard.resources;
 import com.footballstatsdashboard.api.model.ImmutablePlayer;
 import com.footballstatsdashboard.api.model.Player;
 import com.footballstatsdashboard.api.model.User;
+import com.footballstatsdashboard.api.model.club.Club;
+import com.footballstatsdashboard.api.model.player.ImmutableMetadata;
+import com.footballstatsdashboard.api.model.player.Metadata;
 import com.footballstatsdashboard.db.CouchbaseDAO;
 import com.footballstatsdashboard.db.key.ResourceKey;
 import io.dropwizard.auth.Auth;
@@ -70,9 +73,20 @@ public class PlayerResource {
         }
 
         // TODO: 17/04/21 add more internal data when business logic becomes complicated
+        ResourceKey resourceKeyForClub = new ResourceKey(incomingPlayer.getClubId());
+        Club existingClub = this.couchbaseDAO.getDocument(resourceKeyForClub, Club.class);
+        Metadata incomingPlayerMetadata = incomingPlayer.getMetadata();
+        Metadata newPlayerMetadata = ImmutableMetadata.builder()
+                .from(incomingPlayerMetadata)
+                .club(existingClub.getName())
+                .clubLogo("") // TODO: add club logo field here after updating club entity to include it
+                .countryLogo("") // TODO: populate this correctly after implementing client for country flag look up api
+                .build();
+
         LocalDate currentDate = LocalDate.now();
         Player newPlayer = ImmutablePlayer.builder()
                 .from(incomingPlayer)
+                .metadata(newPlayerMetadata)
                 .createdBy(user.getEmail())
                 .createdDate(currentDate)
                 .lastModifiedDate(currentDate)

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/resources/PlayerResource.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/resources/PlayerResource.java
@@ -1,17 +1,9 @@
 package com.footballstatsdashboard.resources;
 
-import com.footballstatsdashboard.api.model.ImmutablePlayer;
 import com.footballstatsdashboard.api.model.Player;
 import com.footballstatsdashboard.api.model.User;
-import com.footballstatsdashboard.api.model.club.Club;
-import com.footballstatsdashboard.api.model.player.Attribute;
-import com.footballstatsdashboard.api.model.player.ImmutableAttribute;
-import com.footballstatsdashboard.api.model.player.ImmutableMetadata;
-import com.footballstatsdashboard.api.model.player.Metadata;
-import com.footballstatsdashboard.db.CouchbaseDAO;
-import com.footballstatsdashboard.db.key.ResourceKey;
+import com.footballstatsdashboard.services.PlayerService;
 import io.dropwizard.auth.Auth;
-import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,13 +22,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
-import java.time.LocalDate;
-import java.util.Collections;
-import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
-import static com.footballstatsdashboard.core.utils.Constants.PLAYER_ATTRIBUTE_CATEGORY_MAP;
 import static com.footballstatsdashboard.core.utils.Constants.PLAYER_ID;
 import static com.footballstatsdashboard.core.utils.Constants.PLAYER_ID_PATH;
 import static com.footballstatsdashboard.core.utils.Constants.PLAYER_V1_BASE_PATH;
@@ -46,11 +33,11 @@ import static com.footballstatsdashboard.core.utils.Constants.PLAYER_V1_BASE_PAT
 public class PlayerResource {
     private static final Logger LOGGER = LoggerFactory.getLogger(PlayerResource.class);
 
-    private final CouchbaseDAO<ResourceKey> couchbaseDAO;
-    public PlayerResource(CouchbaseDAO<ResourceKey> couchbaseDAO) {
-        this.couchbaseDAO = couchbaseDAO;
+    private final PlayerService playerService;
+    public PlayerResource(PlayerService playerService) {
+        this.playerService = playerService;
     }
-    
+
     @GET
     @Path(PLAYER_ID_PATH)
     public Response getPlayer(
@@ -60,8 +47,7 @@ public class PlayerResource {
             LOGGER.info("getPlayer() request for player with ID: {}", playerId.toString());
         }
 
-        ResourceKey resourceKey = new ResourceKey(playerId);
-        Player player = this.couchbaseDAO.getDocument(resourceKey, Player.class);
+        Player player = this.playerService.getPlayer(playerId);
         return Response.ok(player).build();
     }
 
@@ -80,41 +66,7 @@ public class PlayerResource {
         }
 
         // TODO: 17/04/21 add more internal data when business logic becomes complicated
-        ResourceKey resourceKeyForClub = new ResourceKey(incomingPlayer.getClubId());
-        Club existingClub = this.couchbaseDAO.getDocument(resourceKeyForClub, Club.class);
-        Metadata incomingPlayerMetadata = incomingPlayer.getMetadata();
-        Metadata newPlayerMetadata = ImmutableMetadata.builder()
-                .from(incomingPlayerMetadata)
-                .club(existingClub.getName())
-                .clubLogo("") // TODO: add club logo field here after updating club entity to include it
-                .countryLogo("") // TODO: populate this correctly after implementing client for country flag look up api
-                .build();
-
-        List<Attribute> newPlayerAttributes = incomingPlayer.getAttributes().stream()
-                .map(attribute -> {
-                    Pair<String, String> categoryAndGroupNamePair =
-                            PLAYER_ATTRIBUTE_CATEGORY_MAP.get(attribute.getName());
-                    return ImmutableAttribute.builder()
-                            .from(attribute)
-                            .category(categoryAndGroupNamePair.getLeft())
-                            .group(categoryAndGroupNamePair.getRight())
-                            .history(Collections.singletonList(attribute.getValue()))
-                            .build();
-                })
-                .collect(Collectors.toList());
-
-        LocalDate currentDate = LocalDate.now();
-        Player newPlayer = ImmutablePlayer.builder()
-                .from(incomingPlayer)
-                .metadata(newPlayerMetadata)
-                .attributes(newPlayerAttributes)
-                .createdBy(user.getEmail())
-                .createdDate(currentDate)
-                .lastModifiedDate(currentDate)
-                .build();
-
-        ResourceKey resourceKey = new ResourceKey(newPlayer.getId());
-        this.couchbaseDAO.insertDocument(resourceKey, newPlayer);
+        Player newPlayer = this.playerService.createPlayer(incomingPlayer, user.getEmail());
 
         URI location = uriInfo.getAbsolutePathBuilder().path(newPlayer.getId().toString()).build();
         return Response.created(location).entity(newPlayer).build();
@@ -131,41 +83,11 @@ public class PlayerResource {
             LOGGER.info("updatePlayer() request for player with ID: {}", playerId.toString());
         }
 
-        ResourceKey resourceKey = new ResourceKey(playerId);
-        Player existingPlayer = this.couchbaseDAO.getDocument(resourceKey, Player.class);
-
+        Player existingPlayer = this.playerService.getPlayer(playerId);
         // incoming player's basic details should match with that of the existing player
         if (existingPlayer.getId().equals(incomingPlayer.getId())) {
-
             // TODO: 15/04/21 add validations by checking incoming player data against existing one
-            List<Attribute> updatedPlayerAttributes = incomingPlayer.getAttributes().stream()
-                    .map(incomingAttribute -> {
-                        Attribute existingPlayerAttribute = existingPlayer.getAttributes().stream()
-                                .filter(attribute -> attribute.getName().equals(incomingAttribute.getName()))
-                                .findFirst().orElse(null);
-                        if (existingPlayerAttribute != null) {
-                            return ImmutableAttribute.builder()
-                                    .from(existingPlayerAttribute)
-                                    .name(incomingAttribute.getName())
-                                    .value(incomingAttribute.getValue())
-                                    .addHistory(incomingAttribute.getValue())
-                                    .build();
-                        }
-                        // TODO: 1/2/2022 figure out if an error should be thrown if existing player attribute is null
-                        return incomingAttribute;
-                    })
-                    .collect(Collectors.toList());
-            ImmutablePlayer.Builder updatedPlayerBuilder = ImmutablePlayer.builder()
-                    .from(existingPlayer)
-                    .metadata(incomingPlayer.getMetadata())
-                    .ability(incomingPlayer.getAbility())
-                    .roles(incomingPlayer.getRoles())
-                    .attributes(updatedPlayerAttributes)
-                    .lastModifiedDate(LocalDate.now())
-                    .createdBy(user.getEmail());
-
-            Player updatedPlayer = updatedPlayerBuilder.build();
-            this.couchbaseDAO.updateDocument(resourceKey, updatedPlayer);
+            Player updatedPlayer = this.playerService.updatePlayer(incomingPlayer, existingPlayer, playerId);
             return Response.ok(updatedPlayer).build();
         }
         return Response.serverError()
@@ -182,9 +104,7 @@ public class PlayerResource {
             LOGGER.info("deletePlayer() request for player with ID: {}", playerId);
         }
 
-        ResourceKey resourceKey = new ResourceKey(playerId);
-        this.couchbaseDAO.deleteDocument(resourceKey);
-
+        this.playerService.deletePlayer(playerId);
         return Response.noContent().build();
     }
 }

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/PlayerService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/PlayerService.java
@@ -39,15 +39,11 @@ public class PlayerService {
         return this.couchbaseDAO.getDocument(resourceKey, Player.class);
     }
 
-    public Player createPlayer(Player incomingPlayer, String createdBy) {
-        // fetch details of club the incoming player belongs to
-        ResourceKey resourceKeyForClub = new ResourceKey(incomingPlayer.getClubId());
-        Club existingClub = this.couchbaseDAO.getDocument(resourceKeyForClub, Club.class);
-
+    public Player createPlayer(Player incomingPlayer, Club clubDataForNewPlayer, String createdBy) {
         // add club information and other derived information to the metadata entity
         Metadata newPlayerMetadata = ImmutableMetadata.builder()
                 .from(incomingPlayer.getMetadata())
-                .club(existingClub.getName())
+                .club(clubDataForNewPlayer.getName())
                 .clubLogo("") // TODO: add club logo field here after updating club entity to include it
                 .countryLogo("") // TODO: populate this correctly after implementing client for country flag look up api
                 .build();

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/PlayerService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/PlayerService.java
@@ -24,7 +24,12 @@ import java.util.stream.Collectors;
 import static com.footballstatsdashboard.core.utils.Constants.PLAYER_ATTRIBUTE_CATEGORY_MAP;
 
 public class PlayerService {
+    // TODO: 1/4/2022 remove suppression if and when we switch to using enum for attribute categories since we can
+    //  infer the number of categories from it
+    private static final int NUMBER_OF_ATTRIBUTE_CATEGORIES = 3;
+
     private final CouchbaseDAO<ResourceKey> couchbaseDAO;
+
     public PlayerService(CouchbaseDAO<ResourceKey> couchbaseDAO) {
         this.couchbaseDAO = couchbaseDAO;
     }
@@ -134,9 +139,6 @@ public class PlayerService {
         this.couchbaseDAO.deleteDocument(resourceKey);
     }
 
-    // TODO: 1/4/2022 remove suppression if and when we switch to using enum for attribute categories since we can
-    //  infer the number of categories from it
-    @SuppressWarnings("checkstyle:MagicNumber")
     private Integer calculateCurrentAbility(List<Attribute> playerAttributes) {
         double meanTechnicalAbility =  playerAttributes.stream()
                 .filter(attribute -> "Technical".equals(attribute.getCategory()))
@@ -159,6 +161,8 @@ public class PlayerService {
                 || Double.isNaN(meanMentalAbility)) {
             return null;
         }
-        return Math.toIntExact(Math.round((meanTechnicalAbility + meanPhysicalAbility + meanPhysicalAbility) / 3));
+        return Math.toIntExact(Math.round(
+                (meanTechnicalAbility + meanPhysicalAbility + meanPhysicalAbility) / NUMBER_OF_ATTRIBUTE_CATEGORIES
+        ));
     }
 }

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/PlayerService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/PlayerService.java
@@ -1,0 +1,122 @@
+package com.footballstatsdashboard.services;
+
+import com.footballstatsdashboard.api.model.ImmutablePlayer;
+import com.footballstatsdashboard.api.model.Player;
+import com.footballstatsdashboard.api.model.club.Club;
+import com.footballstatsdashboard.api.model.player.Attribute;
+import com.footballstatsdashboard.api.model.player.ImmutableAttribute;
+import com.footballstatsdashboard.api.model.player.ImmutableMetadata;
+import com.footballstatsdashboard.api.model.player.Metadata;
+import com.footballstatsdashboard.db.CouchbaseDAO;
+import com.footballstatsdashboard.db.key.ResourceKey;
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static com.footballstatsdashboard.core.utils.Constants.PLAYER_ATTRIBUTE_CATEGORY_MAP;
+
+public class PlayerService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlayerService.class);
+
+    private final CouchbaseDAO<ResourceKey> couchbaseDAO;
+    public PlayerService(CouchbaseDAO<ResourceKey> couchbaseDAO) {
+        this.couchbaseDAO = couchbaseDAO;
+    }
+
+    public Player getPlayer(UUID playerId) {
+        ResourceKey resourceKey = new ResourceKey(playerId);
+        return this.couchbaseDAO.getDocument(resourceKey, Player.class);
+    }
+
+    public Player createPlayer(Player incomingPlayer, String createdBy) {
+        // fetch details of club the incoming player belongs to
+        ResourceKey resourceKeyForClub = new ResourceKey(incomingPlayer.getClubId());
+        Club existingClub = this.couchbaseDAO.getDocument(resourceKeyForClub, Club.class);
+
+        // add club information and other derived information to the metadata entity
+        Metadata newPlayerMetadata = ImmutableMetadata.builder()
+                .from(incomingPlayer.getMetadata())
+                .club(existingClub.getName())
+                .clubLogo("") // TODO: add club logo field here after updating club entity to include it
+                .countryLogo("") // TODO: populate this correctly after implementing client for country flag look up api
+                .build();
+
+        // add category and group information to each attribute on the player entity
+        // also, initialize the attribute history with the current value
+        List<Attribute> newPlayerAttributes = incomingPlayer.getAttributes().stream()
+                .map(attribute -> {
+                    Pair<String, String> categoryAndGroupNamePair =
+                            PLAYER_ATTRIBUTE_CATEGORY_MAP.get(attribute.getName());
+                    return ImmutableAttribute.builder()
+                            .from(attribute)
+                            .category(categoryAndGroupNamePair.getLeft())
+                            .group(categoryAndGroupNamePair.getRight())
+                            .history(Collections.singletonList(attribute.getValue()))
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        // TODO: calculate the player's current ability on the basis of the attributes
+        //  also initialize the ability history with that value
+
+        LocalDate currentDate = LocalDate.now();
+        Player newPlayer = ImmutablePlayer.builder()
+                .from(incomingPlayer)
+                .metadata(newPlayerMetadata)
+                .attributes(newPlayerAttributes)
+                .createdBy(createdBy)
+                .createdDate(currentDate)
+                .lastModifiedDate(currentDate)
+                .build();
+
+        ResourceKey resourceKey = new ResourceKey(newPlayer.getId());
+        this.couchbaseDAO.insertDocument(resourceKey, newPlayer);
+
+        return newPlayer;
+    }
+
+    public Player updatePlayer(Player incomingPlayer, Player existingPlayer, UUID playerId) {
+        ResourceKey resourceKey = new ResourceKey(playerId);
+
+        List<Attribute> updatedPlayerAttributes = incomingPlayer.getAttributes().stream()
+                .map(incomingAttribute -> {
+                    Attribute existingPlayerAttribute = existingPlayer.getAttributes().stream()
+                            .filter(attribute -> attribute.getName().equals(incomingAttribute.getName()))
+                            .findFirst().orElse(null);
+                    if (existingPlayerAttribute != null) {
+                        return ImmutableAttribute.builder()
+                                .from(existingPlayerAttribute)
+                                .name(incomingAttribute.getName())
+                                .value(incomingAttribute.getValue())
+                                .addHistory(incomingAttribute.getValue())
+                                .build();
+                    }
+                    // TODO: 1/2/2022 figure out if an error should be thrown if existing player attribute is null
+                    return incomingAttribute;
+                })
+                .collect(Collectors.toList());
+        ImmutablePlayer.Builder updatedPlayerBuilder = ImmutablePlayer.builder()
+                .from(existingPlayer)
+                .metadata(incomingPlayer.getMetadata())
+                .ability(incomingPlayer.getAbility())
+                .roles(incomingPlayer.getRoles())
+                .attributes(updatedPlayerAttributes)
+                .lastModifiedDate(LocalDate.now());
+
+        Player updatedPlayer = updatedPlayerBuilder.build();
+        this.couchbaseDAO.updateDocument(resourceKey, updatedPlayer);
+        return updatedPlayer;
+    }
+
+    // TODO: 1/3/2022 add checks to make sure player being deleted belongs to the club and user making the request
+    public void deletePlayer(UUID playerId) {
+        ResourceKey resourceKey = new ResourceKey(playerId);
+        this.couchbaseDAO.deleteDocument(resourceKey);
+    }
+}

--- a/dashboard-server/src/main/resources/api/examples/player-post-request.json
+++ b/dashboard-server/src/main/resources/api/examples/player-post-request.json
@@ -26,7 +26,7 @@
     {
       "category": "Technical",
       "group": "Attacking",
-      "name": "FK Accuracy",
+      "name": "freekick accuracy",
       "value": 2,
       "history": [
         15,
@@ -310,7 +310,7 @@
       ]
     },
     {
-      "category": "Physical",
+      "category": "Mental",
       "group": "Vision",
       "name": "vision",
       "value": 19,
@@ -323,7 +323,7 @@
       ]
     },
     {
-      "category": "Physical",
+      "category": "Mental",
       "group": "Attacking",
       "name": "composure",
       "value": 10,
@@ -336,7 +336,7 @@
       ]
     },
     {
-      "category": "Physical",
+      "category": "Mental",
       "group": "Defending",
       "name": "defensive awareness",
       "value": 11,
@@ -349,7 +349,7 @@
       ]
     },
     {
-      "category": "Physical",
+      "category": "Mental",
       "group": "Attacking",
       "name": "attacking position",
       "value": 14,

--- a/dashboard-server/src/main/resources/api/examples/player-post-request.json
+++ b/dashboard-server/src/main/resources/api/examples/player-post-request.json
@@ -1,17 +1,12 @@
 {
   "metadata": {
     "name": "Sander Gard Bolin Berge",
-    "dateOfBirth": "2020-04-18T19:51:19.285Z",
-    "club": "Sheffield United",
     "country": "Norway",
-    "photo": "http://lorempixel.com/640/480/people?random=7",
-    "clubLogo": "http://lorempixel.com/640/480/abstract?random=11",
-    "countryLogo": "https://s3.amazonaws.com/uifaces/faces/twitter/j04ntoh/128.jpg?random=1",
     "age": 22
   },
   "roles": [
     {
-      "name": "defensiveCentralMidfielder",
+      "name": "defensive central midfielder",
       "associatedAttributes": [
         "interceptions",
         "defensive awareness",
@@ -24,353 +19,108 @@
   ],
   "attributes": [
     {
-      "category": "Technical",
-      "group": "Attacking",
       "name": "freekick accuracy",
-      "value": 2,
-      "history": [
-        15,
-        20,
-        7,
-        18,
-        11
-      ]
+      "value": 2
     },
     {
-      "category": "Technical",
-      "groupName": "Attacking",
       "name": "penalties",
-      "value": 9,
-      "history": [
-        13,
-        0,
-        14,
-        7,
-        18
-      ]
+      "value": 9
     },
     {
-      "category": "Technical",
-      "group": "Aerial",
       "name": "heading accuracy",
-      "value": 3,
-      "history": [
-        18,
-        8,
-        17,
-        9,
-        7
-      ]
+      "value": 3
     },
     {
-      "category": "Technical",
-      "group": "Attacking",
       "name": "crossing",
-      "value": 1,
-      "history": [
-        5,
-        2,
-        17,
-        2,
-        14
-      ]
+      "value": 1
     },
     {
-      "category": "Technical",
-      "group": "Vision",
       "name": "short passing",
-      "value": 16,
-      "history": [
-        1,
-        0,
-        9,
-        15,
-        18
-      ]
+      "value": 16
     },
     {
-      "category": "Technical",
-      "group": "Vision",
       "name": "long passing",
-      "value": 19,
-      "history": [
-        2,
-        10,
-        20,
-        3,
-        14
-      ]
+      "value": 19
     },
     {
-      "category": "Technical",
-      "group": "Attacking",
       "name": "long shots",
-      "value": 16,
-      "history": [
-        16,
-        4,
-        5,
-        13,
-        2
-      ]
+      "value": 16
     },
     {
-      "category": "Technical",
-      "group": "Attacking",
       "name": "finishing",
-      "value": 2,
-      "history": [
-        0,
-        7,
-        5,
-        1,
-        6
-      ]
+      "value": 2
     },
     {
-      "category": "Technical",
-      "group": "Attacking",
       "name": "volleys",
-      "value": 18,
-      "history": [
-        16,
-        19,
-        12,
-        19,
-        10
-      ]
+      "value": 18
     },
     {
-      "category": "Technical",
-      "group": "Attacking",
       "name": "ball control",
-      "value": 9,
-      "history": [
-        17,
-        3,
-        13,
-        12,
-        3
-      ]
+      "value": 9
     },
     {
-      "category": "Technical",
-      "group": "Defending",
       "name": "standing tackle",
-      "value": 8,
-      "history": [
-        5,
-        17,
-        3,
-        8,
-        4
-      ]
+      "value": 8
     },
     {
-      "category": "Technical",
-      "group": "Defending",
       "name": "sliding tackle",
-      "value": 3,
-      "history": [
-        20,
-        3,
-        1,
-        16,
-        2
-      ]
+      "value": 3
     },
     {
-      "category": "Technical",
-      "group": "Attacking",
       "name": "dribbling",
-      "value": 7,
-      "history": [
-        6,
-        7,
-        2,
-        8,
-        5
-      ]
+      "value": 7
     },
     {
-      "category": "Technical",
-      "group": "Attacking",
       "name": "curve",
-      "value": 19,
-      "history": [
-        12,
-        1,
-        7,
-        7,
-        15
-      ]
+      "value": 19
     },
     {
-      "category": "Physical",
-      "group": "Defending",
       "name": "stamina",
-      "value": 19,
-      "history": [
-        13,
-        19,
-        4,
-        10,
-        6
-      ]
+      "value": 19
     },
     {
-      "category": "Physical",
-      "group": "Aerial",
       "name": "jumping",
-      "value": 14,
-      "history": [
-        7,
-        9,
-        0,
-        19,
-        12
-      ]
+      "value": 14
     },
     {
-      "category": "Physical",
-      "group": "Defending",
       "name": "strength",
-      "value": 17,
-      "history": [
-        18,
-        19,
-        6,
-        17,
-        6
-      ]
+      "value": 17
     },
     {
-      "category": "Physical",
-      "group": "Speed",
       "name": "sprint speed",
-      "value": 8,
-      "history": [
-        12,
-        1,
-        17,
-        19,
-        20
-      ]
+      "value": 8
     },
     {
-      "category": "Physical",
-      "group": "Speed",
       "name": "acceleration",
-      "value": 5,
-      "history": [
-        3,
-        5,
-        5,
-        1,
-        2
-      ]
+      "value": 5
     },
     {
-      "category": "Physical",
-      "group": "Speed",
       "name": "agility",
-      "value": 17,
-      "history": [
-        12,
-        8,
-        4,
-        10,
-        11
-      ]
+      "value": 17
     },
     {
-      "category": "Physical",
-      "group": "Speed",
       "name": "balance",
-      "value": 12,
-      "history": [
-        7,
-        9,
-        16,
-        19,
-        16
-      ]
+      "value": 12
     },
     {
-      "category": "Mental",
-      "group": "Attacking",
       "name": "aggression",
-      "value": 0,
-      "history": [
-        6,
-        6,
-        8,
-        12,
-        17
-      ]
+      "value": 0
     },
     {
-      "category": "Mental",
-      "group": "Vision",
       "name": "vision",
-      "value": 19,
-      "history": [
-        3,
-        11,
-        2,
-        3,
-        6
-      ]
+      "value": 19
     },
     {
-      "category": "Mental",
-      "group": "Attacking",
       "name": "composure",
-      "value": 10,
-      "history": [
-        1,
-        14,
-        3,
-        18,
-        12
-      ]
+      "value": 10
     },
     {
-      "category": "Mental",
-      "group": "Defending",
       "name": "defensive awareness",
-      "value": 11,
-      "history": [
-        12,
-        4,
-        17,
-        2,
-        4
-      ]
+      "value": 11
     },
     {
-      "category": "Mental",
-      "group": "Attacking",
       "name": "attacking position",
-      "value": 14,
-      "history": [
-        8,
-        7,
-        9,
-        7,
-        5
-      ]
+      "value": 14
     }
-  ],
-  "ability": {
-    "current": 97,
-    "history": [
-      75,
-      36,
-      56,
-      32,
-      18,
-      97
-    ]
-  }
+  ]
 }

--- a/dashboard-server/src/main/resources/countryCodeMapping.json
+++ b/dashboard-server/src/main/resources/countryCodeMapping.json
@@ -1,0 +1,1026 @@
+[
+  {
+    "countryName": "Andorra,: ",
+    "countryCode": "ad"
+  },
+  {
+    "countryName": "United Arab Emirates",
+    "countryCode": "ae"
+  },
+  {
+    "countryName": "Afghanistan",
+    "countryCode": "af"
+  },
+  {
+    "countryName": "Antigua and Barbuda",
+    "countryCode": "ag"
+  },
+  {
+    "countryName": "Anguilla",
+    "countryCode": "ai"
+  },
+  {
+    "countryName": "Albania",
+    "countryCode": "al"
+  },
+  {
+    "countryName": "Armenia",
+    "countryCode": "am"
+  },
+  {
+    "countryName": "Angola",
+    "countryCode": "ao"
+  },
+  {
+    "countryName": "Antarctica",
+    "countryCode": "aq"
+  },
+  {
+    "countryName": "Argentina",
+    "countryCode": "ar"
+  },
+  {
+    "countryName": "American Samoa",
+    "countryCode": "as"
+  },
+  {
+    "countryName": "Austria",
+    "countryCode": "at"
+  },
+  {
+    "countryName": "Australia",
+    "countryCode": "au"
+  },
+  {
+    "countryName": "Aruba",
+    "countryCode": "aw"
+  },
+  {
+    "countryName": "Åland Islands",
+    "countryCode": "ax"
+  },
+  {
+    "countryName": "Azerbaijan",
+    "countryCode": "az"
+  },
+  {
+    "countryName": "Bosnia and Herzegovina",
+    "countryCode": "ba"
+  },
+  {
+    "countryName": "Barbados",
+    "countryCode": "bb"
+  },
+  {
+    "countryName": "Bangladesh",
+    "countryCode": "bd"
+  },
+  {
+    "countryName": "Belgium",
+    "countryCode": "be"
+  },
+  {
+    "countryName": "Burkina Faso",
+    "countryCode": "bf"
+  },
+  {
+    "countryName": "Bulgaria",
+    "countryCode": "bg"
+  },
+  {
+    "countryName": "Bahrain",
+    "countryCode": "bh"
+  },
+  {
+    "countryName": "Burundi",
+    "countryCode": "bi"
+  },
+  {
+    "countryName": "Benin",
+    "countryCode": "bj"
+  },
+  {
+    "countryName": "Saint Barthélemy",
+    "countryCode": "bl"
+  },
+  {
+    "countryName": "Bermuda",
+    "countryCode": "bm"
+  },
+  {
+    "countryName": "Brunei",
+    "countryCode": "bn"
+  },
+  {
+    "countryName": "Bolivia",
+    "countryCode": "bo"
+  },
+  {
+    "countryName": "Caribbean Netherlands",
+    "countryCode": "bq"
+  },
+  {
+    "countryName": "Brazil",
+    "countryCode": "br"
+  },
+  {
+    "countryName": "Bahamas",
+    "countryCode": "bs"
+  },
+  {
+    "countryName": "Bhutan",
+    "countryCode": "bt"
+  },
+  {
+    "countryName": "Bouvet Island",
+    "countryCode": "bv"
+  },
+  {
+    "countryName": "Botswana",
+    "countryCode": "bw"
+  },
+  {
+    "countryName": "Belarus",
+    "countryCode": "by"
+  },
+  {
+    "countryName": "Belize",
+    "countryCode": "bz"
+  },
+  {
+    "countryName": "Canada",
+    "countryCode": "ca"
+  },
+  {
+    "countryName": "Cocos (Keeling) Islands",
+    "countryCode": "cc"
+  },
+  {
+    "countryName": "DR Congo",
+    "countryCode": "cd"
+  },
+  {
+    "countryName": "Central African Republic",
+    "countryCode": "cf"
+  },
+  {
+    "countryName": "Republic of the Congo",
+    "countryCode": "cg"
+  },
+  {
+    "countryName": "Switzerland",
+    "countryCode": "ch"
+  },
+  {
+    "countryName": "Côte d\"Ivoire (Ivory Coast)",
+    "countryCode": "ci"
+  },
+  {
+    "countryName": "Cook Islands",
+    "countryCode": "ck"
+  },
+  {
+    "countryName": "Chile",
+    "countryCode": "cl"
+  },
+  {
+    "countryName": "Cameroon",
+    "countryCode": "cm"
+  },
+  {
+    "countryName": "China",
+    "countryCode": "cn"
+  },
+  {
+    "countryName": "Colombia",
+    "countryCode": "co"
+  },
+  {
+    "countryName": "Costa Rica",
+    "countryCode": "cr"
+  },
+  {
+    "countryName": "Cuba",
+    "countryCode": "cu"
+  },
+  {
+    "countryName": "Cape Verde",
+    "countryCode": "cv"
+  },
+  {
+    "countryName": "Curaçao",
+    "countryCode": "cw"
+  },
+  {
+    "countryName": "Christmas Island",
+    "countryCode": "cx"
+  },
+  {
+    "countryName": "Cyprus",
+    "countryCode": "cy"
+  },
+  {
+    "countryName": "Czechia",
+    "countryCode": "cz"
+  },
+  {
+    "countryName": "Germany",
+    "countryCode": "de"
+  },
+  {
+    "countryName": "Djibouti",
+    "countryCode": "dj"
+  },
+  {
+    "countryName": "Denmark",
+    "countryCode": "dk"
+  },
+  {
+    "countryName": "Dominica",
+    "countryCode": "dm"
+  },
+  {
+    "countryName": "Dominican Republic",
+    "countryCode": "do"
+  },
+  {
+    "countryName": "Algeria",
+    "countryCode": "dz"
+  },
+  {
+    "countryName": "Ecuador",
+    "countryCode": "ec"
+  },
+  {
+    "countryName": "Estonia",
+    "countryCode": "ee"
+  },
+  {
+    "countryName": "Egypt",
+    "countryCode": "eg"
+  },
+  {
+    "countryName": "Western Sahara",
+    "countryCode": "eh"
+  },
+  {
+    "countryName": "Eritrea",
+    "countryCode": "er"
+  },
+  {
+    "countryName": "Spain",
+    "countryCode": "es"
+  },
+  {
+    "countryName": "Ethiopia",
+    "countryCode": "et"
+  },
+  {
+    "countryName": "European Union",
+    "countryCode": "eu"
+  },
+  {
+    "countryName": "Finland",
+    "countryCode": "fi"
+  },
+  {
+    "countryName": "Fiji",
+    "countryCode": "fj"
+  },
+  {
+    "countryName": "Falkland Islands",
+    "countryCode": "fk"
+  },
+  {
+    "countryName": "Micronesia",
+    "countryCode": "fm"
+  },
+  {
+    "countryName": "Faroe Islands",
+    "countryCode": "fo"
+  },
+  {
+    "countryName": "France",
+    "countryCode": "fr"
+  },
+  {
+    "countryName": "Gabon",
+    "countryCode": "ga"
+  },
+  {
+    "countryName": "United Kingdom",
+    "countryCode": "gb"
+  },
+  {
+    "countryName": "England",
+    "countryCode": "gb-eng"
+  },
+  {
+    "countryName": "Northern Ireland",
+    "countryCode": "gb-nir"
+  },
+  {
+    "countryName": "Scotland",
+    "countryCode": "gb-sct"
+  },
+  {
+    "countryName": "Wales",
+    "countryCode": "gb-wls"
+  },
+  {
+    "countryName": "Grenada",
+    "countryCode": "gd"
+  },
+  {
+    "countryName": "Georgia",
+    "countryCode": "ge"
+  },
+  {
+    "countryName": "French Guiana",
+    "countryCode": "gf"
+  },
+  {
+    "countryName": "Guernsey",
+    "countryCode": "gg"
+  },
+  {
+    "countryName": "Ghana",
+    "countryCode": "gh"
+  },
+  {
+    "countryName": "Gibraltar",
+    "countryCode": "gi"
+  },
+  {
+    "countryName": "Greenland",
+    "countryCode": "gl"
+  },
+  {
+    "countryName": "Gambia",
+    "countryCode": "gm"
+  },
+  {
+    "countryName": "Guinea",
+    "countryCode": "gn"
+  },
+  {
+    "countryName": "Guadeloupe",
+    "countryCode": "gp"
+  },
+  {
+    "countryName": "Equatorial Guinea",
+    "countryCode": "gq"
+  },
+  {
+    "countryName": "Greece",
+    "countryCode": "gr"
+  },
+  {
+    "countryName": "South Georgia",
+    "countryCode": "gs"
+  },
+  {
+    "countryName": "Guatemala",
+    "countryCode": "gt"
+  },
+  {
+    "countryName": "Guam",
+    "countryCode": "gu"
+  },
+  {
+    "countryName": "Guinea-Bissau",
+    "countryCode": "gw"
+  },
+  {
+    "countryName": "Guyana",
+    "countryCode": "gy"
+  },
+  {
+    "countryName": "Hong Kong",
+    "countryCode": "hk"
+  },
+  {
+    "countryName": "Heard Island and McDonald Islands",
+    "countryCode": "hm"
+  },
+  {
+    "countryName": "Honduras",
+    "countryCode": "hn"
+  },
+  {
+    "countryName": "Croatia",
+    "countryCode": "hr"
+  },
+  {
+    "countryName": "Haiti",
+    "countryCode": "ht"
+  },
+  {
+    "countryName": "Hungary",
+    "countryCode": "hu"
+  },
+  {
+    "countryName": "Indonesia",
+    "countryCode": "id"
+  },
+  {
+    "countryName": "Ireland",
+    "countryCode": "ie"
+  },
+  {
+    "countryName": "Israel",
+    "countryCode": "il"
+  },
+  {
+    "countryName": "Isle of Man",
+    "countryCode": "im"
+  },
+  {
+    "countryName": "India",
+    "countryCode": "in"
+  },
+  {
+    "countryName": "British Indian Ocean Territory",
+    "countryCode": "io"
+  },
+  {
+    "countryName": "Iraq",
+    "countryCode": "iq"
+  },
+  {
+    "countryName": "Iran",
+    "countryCode": "ir"
+  },
+  {
+    "countryName": "Iceland",
+    "countryCode": "is"
+  },
+  {
+    "countryName": "Italy",
+    "countryCode": "it"
+  },
+  {
+    "countryName": "Jersey",
+    "countryCode": "je"
+  },
+  {
+    "countryName": "Jamaica",
+    "countryCode": "jm"
+  },
+  {
+    "countryName": "Jordan",
+    "countryCode": "jo"
+  },
+  {
+    "countryName": "Japan",
+    "countryCode": "jp"
+  },
+  {
+    "countryName": "Kenya",
+    "countryCode": "ke"
+  },
+  {
+    "countryName": "Kyrgyzstan",
+    "countryCode": "kg"
+  },
+  {
+    "countryName": "Cambodia",
+    "countryCode": "kh"
+  },
+  {
+    "countryName": "Kiribati",
+    "countryCode": "ki"
+  },
+  {
+    "countryName": "Comoros",
+    "countryCode": "km"
+  },
+  {
+    "countryName": "Saint Kitts and Nevis",
+    "countryCode": "kn"
+  },
+  {
+    "countryName": "North Korea",
+    "countryCode": "kp"
+  },
+  {
+    "countryName": "South Korea",
+    "countryCode": "kr"
+  },
+  {
+    "countryName": "Kuwait",
+    "countryCode": "kw"
+  },
+  {
+    "countryName": "Cayman Islands",
+    "countryCode": "ky"
+  },
+  {
+    "countryName": "Kazakhstan",
+    "countryCode": "kz"
+  },
+  {
+    "countryName": "Laos",
+    "countryCode": "la"
+  },
+  {
+    "countryName": "Lebanon",
+    "countryCode": "lb"
+  },
+  {
+    "countryName": "Saint Lucia",
+    "countryCode": "lc"
+  },
+  {
+    "countryName": "Liechtenstein",
+    "countryCode": "li"
+  },
+  {
+    "countryName": "Sri Lanka",
+    "countryCode": "lk"
+  },
+  {
+    "countryName": "Liberia",
+    "countryCode": "lr"
+  },
+  {
+    "countryName": "Lesotho",
+    "countryCode": "ls"
+  },
+  {
+    "countryName": "Lithuania",
+    "countryCode": "lt"
+  },
+  {
+    "countryName": "Luxembourg",
+    "countryCode": "lu"
+  },
+  {
+    "countryName": "Latvia",
+    "countryCode": "lv"
+  },
+  {
+    "countryName": "Libya",
+    "countryCode": "ly"
+  },
+  {
+    "countryName": "Morocco",
+    "countryCode": "ma"
+  },
+  {
+    "countryName": "Monaco",
+    "countryCode": "mc"
+  },
+  {
+    "countryName": "Moldova",
+    "countryCode": "md"
+  },
+  {
+    "countryName": "Montenegro",
+    "countryCode": "me"
+  },
+  {
+    "countryName": "Saint Martin",
+    "countryCode": "mf"
+  },
+  {
+    "countryName": "Madagascar",
+    "countryCode": "mg"
+  },
+  {
+    "countryName": "Marshall Islands",
+    "countryCode": "mh"
+  },
+  {
+    "countryName": "North Macedonia",
+    "countryCode": "mk"
+  },
+  {
+    "countryName": "Mali",
+    "countryCode": "ml"
+  },
+  {
+    "countryName": "Myanmar",
+    "countryCode": "mm"
+  },
+  {
+    "countryName": "Mongolia",
+    "countryCode": "mn"
+  },
+  {
+    "countryName": "Macau",
+    "countryCode": "mo"
+  },
+  {
+    "countryName": "Northern Mariana Islands",
+    "countryCode": "mp"
+  },
+  {
+    "countryName": "Martinique",
+    "countryCode": "mq"
+  },
+  {
+    "countryName": "Mauritania",
+    "countryCode": "mr"
+  },
+  {
+    "countryName": "Montserrat",
+    "countryCode": "ms"
+  },
+  {
+    "countryName": "Malta",
+    "countryCode": "mt"
+  },
+  {
+    "countryName": "Mauritius",
+    "countryCode": "mu"
+  },
+  {
+    "countryName": "Maldives",
+    "countryCode": "mv"
+  },
+  {
+    "countryName": "Malawi",
+    "countryCode": "mw"
+  },
+  {
+    "countryName": "Mexico",
+    "countryCode": "mx"
+  },
+  {
+    "countryName": "Malaysia",
+    "countryCode": "my"
+  },
+  {
+    "countryName": "Mozambique",
+    "countryCode": "mz"
+  },
+  {
+    "countryName": "Namibia",
+    "countryCode": "na"
+  },
+  {
+    "countryName": "New Caledonia",
+    "countryCode": "nc"
+  },
+  {
+    "countryName": "Niger",
+    "countryCode": "ne"
+  },
+  {
+    "countryName": "Norfolk Island",
+    "countryCode": "nf"
+  },
+  {
+    "countryName": "Nigeria",
+    "countryCode": "ng"
+  },
+  {
+    "countryName": "Nicaragua",
+    "countryCode": "ni"
+  },
+  {
+    "countryName": "Netherlands",
+    "countryCode": "nl"
+  },
+  {
+    "countryName": "Norway",
+    "countryCode": "no"
+  },
+  {
+    "countryName": "Nepal",
+    "countryCode": "np"
+  },
+  {
+    "countryName": "Nauru",
+    "countryCode": "nr"
+  },
+  {
+    "countryName": "Niue",
+    "countryCode": "nu"
+  },
+  {
+    "countryName": "New Zealand",
+    "countryCode": "nz"
+  },
+  {
+    "countryName": "Oman",
+    "countryCode": "om"
+  },
+  {
+    "countryName": "Panama",
+    "countryCode": "pa"
+  },
+  {
+    "countryName": "Peru",
+    "countryCode": "pe"
+  },
+  {
+    "countryName": "French Polynesia",
+    "countryCode": "pf"
+  },
+  {
+    "countryName": "Papua New Guinea",
+    "countryCode": "pg"
+  },
+  {
+    "countryName": "Philippines",
+    "countryCode": "ph"
+  },
+  {
+    "countryName": "Pakistan",
+    "countryCode": "pk"
+  },
+  {
+    "countryName": "Poland",
+    "countryCode": "pl"
+  },
+  {
+    "countryName": "Saint Pierre and Miquelon",
+    "countryCode": "pm"
+  },
+  {
+    "countryName": "Pitcairn Islands",
+    "countryCode": "pn"
+  },
+  {
+    "countryName": "Puerto Rico",
+    "countryCode": "pr"
+  },
+  {
+    "countryName": "Palestine",
+    "countryCode": "ps"
+  },
+  {
+    "countryName": "Portugal",
+    "countryCode": "pt"
+  },
+  {
+    "countryName": "Palau",
+    "countryCode": "pw"
+  },
+  {
+    "countryName": "Paraguay",
+    "countryCode": "py"
+  },
+  {
+    "countryName": "Qatar",
+    "countryCode": "qa"
+  },
+  {
+    "countryName": "Réunion",
+    "countryCode": "re"
+  },
+  {
+    "countryName": "Romania",
+    "countryCode": "ro"
+  },
+  {
+    "countryName": "Serbia",
+    "countryCode": "rs"
+  },
+  {
+    "countryName": "Russia",
+    "countryCode": "ru"
+  },
+  {
+    "countryName": "Rwanda",
+    "countryCode": "rw"
+  },
+  {
+    "countryName": "Saudi Arabia",
+    "countryCode": "sa"
+  },
+  {
+    "countryName": "Solomon Islands",
+    "countryCode": "sb"
+  },
+  {
+    "countryName": "Seychelles",
+    "countryCode": "sc"
+  },
+  {
+    "countryName": "Sudan",
+    "countryCode": "sd"
+  },
+  {
+    "countryName": "Sweden",
+    "countryCode": "se"
+  },
+  {
+    "countryName": "Singapore",
+    "countryCode": "sg"
+  },
+  {
+    "countryName": "Saint Helena, Ascension and Tristan da Cunha",
+    "countryCode": "sh"
+  },
+  {
+    "countryName": "Slovenia",
+    "countryCode": "si"
+  },
+  {
+    "countryName": "Svalbard and Jan Mayen",
+    "countryCode": "sj"
+  },
+  {
+    "countryName": "Slovakia",
+    "countryCode": "sk"
+  },
+  {
+    "countryName": "Sierra Leone",
+    "countryCode": "sl"
+  },
+  {
+    "countryName": "San Marino",
+    "countryCode": "sm"
+  },
+  {
+    "countryName": "Senegal",
+    "countryCode": "sn"
+  },
+  {
+    "countryName": "Somalia",
+    "countryCode": "so"
+  },
+  {
+    "countryName": "Suriname",
+    "countryCode": "sr"
+  },
+  {
+    "countryName": "South Sudan",
+    "countryCode": "ss"
+  },
+  {
+    "countryName": "São Tomé and Príncipe",
+    "countryCode": "st"
+  },
+  {
+    "countryName": "El Salvador",
+    "countryCode": "sv"
+  },
+  {
+    "countryName": "Sint Maarten",
+    "countryCode": "sx"
+  },
+  {
+    "countryName": "Syria",
+    "countryCode": "sy"
+  },
+  {
+    "countryName": "Eswatini (Swaziland)",
+    "countryCode": "sz"
+  },
+  {
+    "countryName": "Turks and Caicos Islands",
+    "countryCode": "tc"
+  },
+  {
+    "countryName": "Chad",
+    "countryCode": "td"
+  },
+  {
+    "countryName": "French Southern and Antarctic Lands",
+    "countryCode": "tf"
+  },
+  {
+    "countryName": "Togo",
+    "countryCode": "tg"
+  },
+  {
+    "countryName": "Thailand",
+    "countryCode": "th"
+  },
+  {
+    "countryName": "Tajikistan",
+    "countryCode": "tj"
+  },
+  {
+    "countryName": "Tokelau",
+    "countryCode": "tk"
+  },
+  {
+    "countryName": "Timor-Leste",
+    "countryCode": "tl"
+  },
+  {
+    "countryName": "Turkmenistan",
+    "countryCode": "tm"
+  },
+  {
+    "countryName": "Tunisia",
+    "countryCode": "tn"
+  },
+  {
+    "countryName": "Tonga",
+    "countryCode": "to"
+  },
+  {
+    "countryName": "Turkey",
+    "countryCode": "tr"
+  },
+  {
+    "countryName": "Trinidad and Tobago",
+    "countryCode": "tt"
+  },
+  {
+    "countryName": "Tuvalu",
+    "countryCode": "tv"
+  },
+  {
+    "countryName": "Taiwan",
+    "countryCode": "tw"
+  },
+  {
+    "countryName": "Tanzania",
+    "countryCode": "tz"
+  },
+  {
+    "countryName": "Ukraine",
+    "countryCode": "ua"
+  },
+  {
+    "countryName": "Uganda",
+    "countryCode": "ug"
+  },
+  {
+    "countryName": "United States Minor Outlying Islands",
+    "countryCode": "um"
+  },
+  {
+    "countryName": "United Nations",
+    "countryCode": "un"
+  },
+  {
+    "countryName": "United States",
+    "countryCode": "us"
+  },
+  {
+    "countryName": "Uruguay",
+    "countryCode": "uy"
+  },
+  {
+    "countryName": "Uzbekistan",
+    "countryCode": "uz"
+  },
+  {
+    "countryName": "Vatican City (Holy See)",
+    "countryCode": "va"
+  },
+  {
+    "countryName": "Saint Vincent and the Grenadines",
+    "countryCode": "vc"
+  },
+  {
+    "countryName": "Venezuela",
+    "countryCode": "ve"
+  },
+  {
+    "countryName": "British Virgin Islands",
+    "countryCode": "vg"
+  },
+  {
+    "countryName": "United States Virgin Islands",
+    "countryCode": "vi"
+  },
+  {
+    "countryName": "Vietnam",
+    "countryCode": "vn"
+  },
+  {
+    "countryName": "Vanuatu",
+    "countryCode": "vu"
+  },
+  {
+    "countryName": "Wallis and Futuna",
+    "countryCode": "wf"
+  },
+  {
+    "countryName": "Samoa",
+    "countryCode": "ws"
+  },
+  {
+    "countryName": "Kosovo",
+    "countryCode": "xk"
+  },
+  {
+    "countryName": "Yemen",
+    "countryCode": "ye"
+  },
+  {
+    "countryName": "Mayotte",
+    "countryCode": "yt"
+  },
+  {
+    "countryName": "South Africa",
+    "countryCode": "za"
+  },
+  {
+    "countryName": "Zambia",
+    "countryCode": "zm"
+  },
+  {
+    "countryName": "Zimbabwe",
+    "countryCode": "zw"
+  }
+]

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/PlayerDataProvider.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/PlayerDataProvider.java
@@ -25,6 +25,8 @@ public class PlayerDataProvider {
     private static final int PLAYER_AGE = 27;
     private static final int CURRENT_PLAYER_ABILITY = 19;
     private static final int CURRENT_PLAYER_SPRINT_SPEED = 85;
+    private static final int CURRENT_PLAYER_CROSSING = 80;
+    private static final int CURRENT_PLAYER_COMPOSURE = 75;
     private static final String CREATED_BY = "fake email";
 
     public static final class PlayerBuilder {
@@ -76,14 +78,30 @@ public class PlayerDataProvider {
         }
 
         public PlayerBuilder withAttributes() {
-            Attribute playerAttribute = ImmutableAttribute.builder()
+            Attribute technicalAttribute = ImmutableAttribute.builder()
+                    .name("crossing")
+                    .value(CURRENT_PLAYER_CROSSING)
+                    .category(isExistingPlayer ? "Technical" : null)
+                    .group(isExistingPlayer ? "Attacking" : null)
+                    .history(isExistingPlayer ? ImmutableList.of(CURRENT_PLAYER_CROSSING) : ImmutableList.of())
+                    .build();
+
+            Attribute physicalAttribute = ImmutableAttribute.builder()
                     .name("sprint speed")
                     .value(CURRENT_PLAYER_SPRINT_SPEED)
-                    .category(isExistingPlayer ? "Technical" : null)
+                    .category(isExistingPlayer ? "Physical" : null)
                     .group(isExistingPlayer ? "Speed" : null)
                     .history(isExistingPlayer ? ImmutableList.of(CURRENT_PLAYER_SPRINT_SPEED) : ImmutableList.of())
                     .build();
-            basePlayer.attributes(ImmutableList.of(playerAttribute));
+
+            Attribute mentalAttribute = ImmutableAttribute.builder()
+                    .name("composure")
+                    .value(CURRENT_PLAYER_COMPOSURE)
+                    .category(isExistingPlayer ? "Mental" : null)
+                    .group(isExistingPlayer ? "Attacking" : null)
+                    .history(isExistingPlayer ? ImmutableList.of(CURRENT_PLAYER_COMPOSURE) : ImmutableList.of())
+                    .build();
+            basePlayer.attributes(ImmutableList.of(technicalAttribute, physicalAttribute, mentalAttribute));
             return this;
         }
 

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/PlayerDataProvider.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/PlayerDataProvider.java
@@ -143,8 +143,11 @@ public class PlayerDataProvider {
         }
 
         public ModifiedPlayerBuilder withUpdatedCurrentAbility(int newCurrentAbility) {
-            Ability updatedAbility = ImmutableAbility.builder()
-                    .from(this.playerReference.getAbility())
+            ImmutableAbility.Builder updatedAbilityBuilder = ImmutableAbility.builder();
+            if (this.playerReference.getAbility() != null) {
+                updatedAbilityBuilder.from(this.playerReference.getAbility());
+            }
+            Ability updatedAbility = updatedAbilityBuilder
                     .current(newCurrentAbility)
                     .addHistory(newCurrentAbility)
                     .build();

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/PlayerDataProvider.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/PlayerDataProvider.java
@@ -1,0 +1,168 @@
+package com.footballstatsdashboard;
+
+import com.footballstatsdashboard.api.model.ImmutablePlayer;
+import com.footballstatsdashboard.api.model.Player;
+import com.footballstatsdashboard.api.model.player.Ability;
+import com.footballstatsdashboard.api.model.player.Attribute;
+import com.footballstatsdashboard.api.model.player.ImmutableAbility;
+import com.footballstatsdashboard.api.model.player.ImmutableAttribute;
+import com.footballstatsdashboard.api.model.player.ImmutableMetadata;
+import com.footballstatsdashboard.api.model.player.ImmutableRole;
+import com.footballstatsdashboard.api.model.player.Metadata;
+import com.footballstatsdashboard.api.model.player.Role;
+import com.google.common.collect.ImmutableList;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class PlayerDataProvider {
+
+    private static final int PLAYER_AGE = 27;
+    private static final int CURRENT_PLAYER_ABILITY = 19;
+    private static final int CURRENT_PLAYER_SPRINT_SPEED = 85;
+    private static final String CREATED_BY = "fake email";
+
+    public static final class PlayerBuilder {
+        private boolean isExistingPlayer = false;
+        private final ImmutablePlayer.Builder basePlayer = ImmutablePlayer.builder().clubId(UUID.randomUUID());
+        private PlayerBuilder() { }
+
+        public static PlayerBuilder builder() {
+            return new PlayerBuilder();
+        }
+
+        public PlayerBuilder withId(UUID playerId) {
+            basePlayer.id(playerId);
+            return this;
+        }
+
+        public PlayerBuilder isExistingPlayer(boolean isExisting) {
+            this.isExistingPlayer = isExisting;
+            return this;
+        }
+
+        public PlayerBuilder withAbility() {
+            Ability playerAbility = ImmutableAbility.builder()
+                    .current(CURRENT_PLAYER_ABILITY)
+                    .history(isExistingPlayer ? ImmutableList.of(CURRENT_PLAYER_ABILITY) : ImmutableList.of())
+                    .build();
+            basePlayer.ability(playerAbility);
+            return this;
+        }
+        public PlayerBuilder withMetadata() {
+            Metadata playerMetadata = ImmutableMetadata.builder()
+                    .name("fake player name")
+                    .country("fake country name")
+                    .age(PLAYER_AGE)
+                    .club(isExistingPlayer ? "fake club name" : null)
+                    .clubLogo(isExistingPlayer ? "fake club logo" : null)
+                    .countryLogo(isExistingPlayer ? "fake country logo" : null)
+                    .build();
+            basePlayer.metadata(playerMetadata);
+            return this;
+        }
+
+        public PlayerBuilder withRoles() {
+            Role playerRole = ImmutableRole.builder()
+                    .name("player role")
+                    .build();
+            basePlayer.roles(ImmutableList.of(playerRole));
+            return this;
+        }
+
+        public PlayerBuilder withAttributes() {
+            Attribute playerAttribute = ImmutableAttribute.builder()
+                    .name("sprint speed")
+                    .value(CURRENT_PLAYER_SPRINT_SPEED)
+                    .category(isExistingPlayer ? "Technical" : null)
+                    .group(isExistingPlayer ? "Speed" : null)
+                    .history(isExistingPlayer ? ImmutableList.of(CURRENT_PLAYER_SPRINT_SPEED) : ImmutableList.of())
+                    .build();
+            basePlayer.attributes(ImmutableList.of(playerAttribute));
+            return this;
+        }
+
+        public Player build() {
+            // add some house-keeping fields if it is an existing player
+            if (isExistingPlayer) {
+                Instant currentInstant = Instant.now();
+                Instant olderInstant = currentInstant.minus(1, ChronoUnit.DAYS);
+
+                basePlayer.lastModifiedDate(LocalDate.ofInstant(olderInstant, ZoneId.systemDefault()));
+                basePlayer.createdBy(CREATED_BY);
+            }
+            return this.basePlayer.build();
+        }
+    }
+
+    public static final class ModifiedPlayerBuilder {
+        private Player playerReference;
+        private ImmutablePlayer.Builder basePlayer = ImmutablePlayer.builder();
+        private ModifiedPlayerBuilder() { }
+
+        public static ModifiedPlayerBuilder builder() {
+            return new ModifiedPlayerBuilder();
+        }
+
+        public ModifiedPlayerBuilder from(Player player) {
+            this.playerReference = player;
+            basePlayer = ImmutablePlayer.builder().from(player);
+            return this;
+        }
+
+        public ModifiedPlayerBuilder withUpdatedNameInMetadata(String newPlayerName) {
+            Metadata updatedMetadata = ImmutableMetadata.builder()
+                    .from(this.playerReference.getMetadata())
+                    .name(newPlayerName)
+                    .build();
+            basePlayer.metadata(updatedMetadata);
+            return this;
+        }
+
+        public ModifiedPlayerBuilder withUpdatedCurrentAbility(int newCurrentAbility) {
+            Ability updatedAbility = ImmutableAbility.builder()
+                    .from(this.playerReference.getAbility())
+                    .current(newCurrentAbility)
+                    .addHistory(newCurrentAbility)
+                    .build();
+            basePlayer.ability(updatedAbility);
+            return this;
+        }
+
+        public ModifiedPlayerBuilder withUpdatedRoleName(String newRoleName) {
+            List<Role> updatedPlayerRoles = this.playerReference.getRoles().stream()
+                    .map(role -> ImmutableRole.builder()
+                            .from(role)
+                            .name(newRoleName)
+                            .build()
+                    ).collect(Collectors.toList());
+            basePlayer.roles(updatedPlayerRoles);
+            return this;
+        }
+
+        public ModifiedPlayerBuilder withUpdatedAttributeValue(String attributeName, int newAttributeValue) {
+            List<Attribute> updatedAttributes = this.playerReference.getAttributes().stream()
+                    .map(attribute -> {
+                        if (attributeName.equals(attribute.getName())) {
+                            return ImmutableAttribute.builder()
+                                    .from(attribute)
+                                    .value(newAttributeValue)
+                                    .addHistory(newAttributeValue)
+                                    .build();
+                        }
+                        return attribute;
+                    }).collect(Collectors.toList());
+            basePlayer.attributes(updatedAttributes);
+            return this;
+        }
+
+        public Player build() {
+            return this.basePlayer.build();
+        }
+    }
+}

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/MatchPerformanceResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/MatchPerformanceResourceTest.java
@@ -2,7 +2,7 @@ package com.footballstatsdashboard.resources;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.footballstatsdashboard.FixtureLoader;
+import com.footballstatsdashboard.core.utils.FixtureLoader;
 import com.footballstatsdashboard.api.model.ImmutableMatchPerformance;
 import com.footballstatsdashboard.api.model.ImmutableUser;
 import com.footballstatsdashboard.api.model.MatchPerformance;

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/PlayerResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/PlayerResourceTest.java
@@ -106,7 +106,6 @@ public class PlayerResourceTest {
         Player incomingPlayer = PlayerDataProvider.PlayerBuilder.builder()
                 .isExistingPlayer(false)
                 .withMetadata()
-                .withAbility()
                 .withRoles()
                 .withAttributes()
                 .build();
@@ -141,7 +140,6 @@ public class PlayerResourceTest {
         // setup
         Player incomingPlayer = PlayerDataProvider.PlayerBuilder.builder()
                 .isExistingPlayer(false)
-                .withAbility()
                 .withMetadata()
                 .withAbility()
                 .withAttributes()
@@ -167,7 +165,6 @@ public class PlayerResourceTest {
         Player incomingPlayer = PlayerDataProvider.PlayerBuilder.builder()
                 .isExistingPlayer(false)
                 .withMetadata()
-                .withAbility()
                 .withRoles()
                 .build();
 
@@ -222,7 +219,6 @@ public class PlayerResourceTest {
         Player incomingPlayer = PlayerDataProvider.ModifiedPlayerBuilder.builder()
                 .from(incomingPlayerBase)
                 .withUpdatedNameInMetadata(updatedPlayerName)
-                .withUpdatedCurrentAbility(UPDATED_PLAYER_ABILITY)
                 .withUpdatedRoleName(updatedRoleName)
                 .withUpdatedAttributeValue(updatedAttributeName, UPDATED_PLAYER_SPRINT_SPEED)
                 .build();
@@ -268,7 +264,6 @@ public class PlayerResourceTest {
                 .isExistingPlayer(false)
                 .withId(incomingPlayerId)
                 .withMetadata()
-                .withAbility()
                 .withRoles()
                 .withAttributes()
                 .build();

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/PlayerResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/PlayerResourceTest.java
@@ -34,6 +34,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
@@ -58,6 +59,9 @@ public class PlayerResourceTest {
     private static final int CURRENT_PLAYER_SPRINT_SPEED = 85;
     private static final int UPDATED_PLAYER_ABILITY = 25;
     private static final int UPDATED_PLAYER_SPRINT_SPEED = 87;
+    private static final List<String> PLAYER_ATTRIBUTE_CATEGORIES = ImmutableList.of("Technical", "Physical", "Mental");
+    private static final List<String> PLAYER_ATTRIBUTE_GROUPS = ImmutableList.of("Attacking", "Aerial", "Vision",
+            "Defending", "Speed");
     private static final ObjectMapper OBJECT_MAPPER = Jackson.newObjectMapper().copy();
 
     private PlayerResource playerResource;
@@ -167,6 +171,11 @@ public class PlayerResourceTest {
         assertNotNull(newPlayer.getMetadata().getCountryLogo());
 
         newPlayer.getAttributes().forEach(attribute -> {
+            assertTrue(attribute.getCategory() != null
+                    && PLAYER_ATTRIBUTE_CATEGORIES.contains(attribute.getCategory()));
+            assertTrue(attribute.getGroup() != null
+                    && PLAYER_ATTRIBUTE_GROUPS.contains(attribute.getGroup()));
+            assertNotNull(attribute.getGroup());
             assertEquals(1, attribute.getHistory().size());
             assertEquals(attribute.getValue(), attribute.getHistory().get(0));
         });
@@ -276,6 +285,11 @@ public class PlayerResourceTest {
                     .filter(existingAttribute -> existingAttribute.getName().equals(attribute.getName()))
                     .findFirst().orElse(null);
             assertNotNull(existingPlayerAttribute);
+            assertTrue(attribute.getCategory() != null
+                    && PLAYER_ATTRIBUTE_CATEGORIES.contains(attribute.getCategory()));
+            assertTrue(attribute.getGroup() != null
+                    && PLAYER_ATTRIBUTE_GROUPS.contains(attribute.getGroup()));
+            assertEquals(existingPlayerAttribute.getHistory().size() + 1, attribute.getHistory().size());
             assertEquals(ImmutableList.of(existingPlayerAttribute.getValue(), attribute.getValue()),
                     attribute.getHistory());
         });
@@ -396,10 +410,10 @@ public class PlayerResourceTest {
 
         if (usePlayerAttributes) {
             Attribute playerAttribute = ImmutableAttribute.builder()
-                    .name("Sprint Speed")
+                    .name("sprint speed")
                     .value(CURRENT_PLAYER_SPRINT_SPEED)
-                    .category("Technical")
-                    .group("Speed")
+                    .category(isExistingPlayer ? "Technical" : null)
+                    .group(isExistingPlayer ? "Speed" : null)
                     .history(isExistingPlayer ? ImmutableList.of(CURRENT_PLAYER_SPRINT_SPEED) : ImmutableList.of())
                     .build();
 

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/PlayerResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/PlayerResourceTest.java
@@ -20,6 +20,7 @@ import org.mockito.MockitoAnnotations;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.UUID;
 
@@ -109,7 +110,7 @@ public class PlayerResourceTest {
      * given a valid player entity in the request, tests that the player data is successfully persisted
      */
     @Test
-    public void createPlayerPersistsPlayerData() {
+    public void createPlayerPersistsPlayerData() throws IOException {
         // setup
         Player incomingPlayer = PlayerDataProvider.PlayerBuilder.builder()
                 .isExistingPlayer(false)
@@ -152,7 +153,7 @@ public class PlayerResourceTest {
      * response status is returned
      */
     @Test
-    public void createPlayerWhenPlayerRolesNotProvided() {
+    public void createPlayerWhenPlayerRolesNotProvided() throws IOException {
         // setup
         Player incomingPlayer = PlayerDataProvider.PlayerBuilder.builder()
                 .isExistingPlayer(false)
@@ -177,7 +178,7 @@ public class PlayerResourceTest {
      * 422 response status is returned
      */
     @Test
-    public void createPlayerWhenPlayerAttributesNotProvided() {
+    public void createPlayerWhenPlayerAttributesNotProvided() throws IOException {
         // setup
         Player incomingPlayer = PlayerDataProvider.PlayerBuilder.builder()
                 .isExistingPlayer(false)

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/services/PlayerServiceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/services/PlayerServiceTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -107,7 +106,6 @@ public class PlayerServiceTest {
                 .withAttributes()
                 .build();
         ArgumentCaptor<Player> newPlayerCaptor = ArgumentCaptor.forClass(Player.class);
-        ArgumentCaptor<ResourceKey> clubResourceKeyCaptor = ArgumentCaptor.forClass(ResourceKey.class);
         Club existingClub = ImmutableClub.builder()
                 .name("fake club name")
                 .expenditure(new BigDecimal("1000"))
@@ -115,16 +113,11 @@ public class PlayerServiceTest {
                 .transferBudget(new BigDecimal("500"))
                 .wageBudget(new BigDecimal("200"))
                 .build();
-        when(couchbaseDAO.getDocument(any(), any())).thenReturn(existingClub);
 
         // execute
-        Player createdPlayer = playerService.createPlayer(incomingPlayer, CREATED_BY);
+        Player createdPlayer = playerService.createPlayer(incomingPlayer, existingClub, CREATED_BY);
 
         // assert
-        verify(couchbaseDAO).getDocument(clubResourceKeyCaptor.capture(), eq(Club.class));
-        ResourceKey capturedClubResourceKey = clubResourceKeyCaptor.getValue();
-        assertEquals(incomingPlayer.getClubId(), capturedClubResourceKey.getResourceId());
-
         verify(couchbaseDAO).insertDocument(any(), newPlayerCaptor.capture());
         Player newPlayer = newPlayerCaptor.getValue();
         assertEquals(createdPlayer, newPlayer);

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/services/PlayerServiceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/services/PlayerServiceTest.java
@@ -1,0 +1,315 @@
+package com.footballstatsdashboard.services;
+
+import com.footballstatsdashboard.api.model.ImmutablePlayer;
+import com.footballstatsdashboard.api.model.Player;
+import com.footballstatsdashboard.api.model.club.Club;
+import com.footballstatsdashboard.api.model.club.ImmutableClub;
+import com.footballstatsdashboard.api.model.player.Ability;
+import com.footballstatsdashboard.api.model.player.Attribute;
+import com.footballstatsdashboard.api.model.player.ImmutableAbility;
+import com.footballstatsdashboard.api.model.player.ImmutableAttribute;
+import com.footballstatsdashboard.api.model.player.ImmutableMetadata;
+import com.footballstatsdashboard.api.model.player.ImmutableRole;
+import com.footballstatsdashboard.api.model.player.Metadata;
+import com.footballstatsdashboard.api.model.player.Role;
+import com.footballstatsdashboard.db.CouchbaseDAO;
+import com.footballstatsdashboard.db.key.ResourceKey;
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class PlayerServiceTest {
+    private static final int PLAYER_AGE = 27;
+    private static final int CURRENT_PLAYER_ABILITY = 19;
+    private static final int CURRENT_PLAYER_SPRINT_SPEED = 85;
+    private static final int UPDATED_PLAYER_ABILITY = 25;
+    private static final int UPDATED_PLAYER_SPRINT_SPEED = 87;
+    private static final List<String> PLAYER_ATTRIBUTE_CATEGORIES = ImmutableList.of("Technical", "Physical", "Mental");
+    private static final List<String> PLAYER_ATTRIBUTE_GROUPS = ImmutableList.of("Attacking", "Aerial", "Vision",
+            "Defending", "Speed");
+    public static final String CREATED_BY = "fake email";
+
+    private PlayerService playerService;
+
+    @Mock
+    private CouchbaseDAO<ResourceKey> couchbaseDAO;
+
+    /**
+     * set up test data before each test case is run
+     */
+    @Before
+    public void initialize() {
+        MockitoAnnotations.openMocks(this);
+        playerService = new PlayerService(couchbaseDAO);
+    }
+
+    /**
+     * given a valid player id, tests that the player entity is successfully fetched from couchbase server and
+     * returned in the response
+     */
+    @Test
+    public void getPlayerFetchesPlayerFromCouchbase() {
+        // setup
+        UUID playerId = UUID.randomUUID();
+        Player playerFromCouchbase = getPlayerDataStub(playerId, true, true, true);
+        when(couchbaseDAO.getDocument(any(), any())).thenReturn(playerFromCouchbase);
+
+        // execute
+        Player player = playerService.getPlayer(playerId);
+
+        // assert
+        verify(couchbaseDAO).getDocument(any(), any());
+        assertEquals(playerId, player.getId());
+    }
+
+    /**
+     * given a runtime exception is thrown by couchbase DAO when player entity is not found, verifies that the same
+     * exception is thrown by `getPlayer` resource method as well
+     */
+    @Test(expected = RuntimeException.class)
+    public void getPlayerWhenPlayerNotFoundInCouchbase() {
+        // setup
+        UUID invalidPlayerId = UUID.randomUUID();
+        when(couchbaseDAO.getDocument(any(), any()))
+                .thenThrow(new RuntimeException("Unable to find document with Id: " + invalidPlayerId));
+
+        // execute
+        playerService.getPlayer(invalidPlayerId);
+
+        // assert
+        verify(couchbaseDAO).getDocument(any(), any());
+    }
+
+    /**
+     * given a valid player entity in the request, tests that the internal fields are set correctly on the entity and
+     * persisted in couchbase
+     */
+    @Test
+    public void createPlayerPersistsPlayerInCouchbase() {
+        // setup
+        Player incomingPlayer = getPlayerDataStub(null, true, true, false);
+        ArgumentCaptor<Player> newPlayerCaptor = ArgumentCaptor.forClass(Player.class);
+        ArgumentCaptor<ResourceKey> clubResourceKeyCaptor = ArgumentCaptor.forClass(ResourceKey.class);
+        Club existingClub = ImmutableClub.builder()
+                .name("fake club name")
+                .expenditure(new BigDecimal("1000"))
+                .income(new BigDecimal("2000"))
+                .transferBudget(new BigDecimal("500"))
+                .wageBudget(new BigDecimal("200"))
+                .build();
+        when(couchbaseDAO.getDocument(any(), any())).thenReturn(existingClub);
+
+        // execute
+        Player createdPlayer = playerService.createPlayer(incomingPlayer, CREATED_BY);
+
+        // assert
+        verify(couchbaseDAO).getDocument(clubResourceKeyCaptor.capture(), eq(Club.class));
+        ResourceKey capturedClubResourceKey = clubResourceKeyCaptor.getValue();
+        assertEquals(incomingPlayer.getClubId(), capturedClubResourceKey.getResourceId());
+
+        verify(couchbaseDAO).insertDocument(any(), newPlayerCaptor.capture());
+        Player newPlayer = newPlayerCaptor.getValue();
+        assertEquals(existingClub.getName(), newPlayer.getMetadata().getClub());
+        assertNotNull(newPlayer.getMetadata().getClubLogo());
+
+        // TODO: add assertions to verify country logo property is correctly set on the basis of the country property
+        //  set on the incoming player
+        assertNotNull(newPlayer.getMetadata().getCountryLogo());
+
+        newPlayer.getAttributes().forEach(attribute -> {
+            assertTrue(attribute.getCategory() != null
+                    && PLAYER_ATTRIBUTE_CATEGORIES.contains(attribute.getCategory()));
+            assertTrue(attribute.getGroup() != null
+                    && PLAYER_ATTRIBUTE_GROUPS.contains(attribute.getGroup()));
+            assertNotNull(attribute.getGroup());
+            assertEquals(1, attribute.getHistory().size());
+            assertEquals(attribute.getValue(), attribute.getHistory().get(0));
+        });
+
+        // assertions for general house-keeping fields
+        assertNotNull(newPlayer.getCreatedDate());
+        assertNotNull(newPlayer.getLastModifiedDate());
+        assertEquals(CREATED_BY, newPlayer.getCreatedBy());
+    }
+
+    /**
+     * given a valid player entity in the request, tests that an updated player entity with updated internal fields
+     * is upserted in couchbase
+     */
+    @Test
+    public void updatePlayerUpdatesPlayerInCouchbase() {
+        // setup
+        UUID existingPlayerId = UUID.randomUUID();
+        Player existingPlayerInCouchbase = getPlayerDataStub(existingPlayerId, true, true, true);
+        Player incomingPlayerBase = getPlayerDataStub(existingPlayerId, true, true, false);
+        when(couchbaseDAO.getDocument(any(), any())).thenReturn(existingPlayerInCouchbase);
+
+        Metadata updatedMetadata = ImmutableMetadata.builder()
+                .from(incomingPlayerBase.getMetadata())
+                .name("Updated Name")
+                .build();
+        Ability updatedAbility = ImmutableAbility.builder()
+                .from(incomingPlayerBase.getAbility())
+                .current(UPDATED_PLAYER_ABILITY)
+                .build();
+        Role updatedRole = ImmutableRole.builder()
+                .from(incomingPlayerBase.getRoles().get(0))
+                .name("updated playerRole")
+                .build();
+        Attribute updatedAttribute = ImmutableAttribute.builder()
+                .from(incomingPlayerBase.getAttributes().get(0))
+                .value(UPDATED_PLAYER_SPRINT_SPEED)
+                .build();
+
+        Player incomingPlayer = ImmutablePlayer.builder()
+                .from(incomingPlayerBase)
+                .metadata(updatedMetadata)
+                .ability(updatedAbility)
+                .roles(ImmutableList.of(updatedRole))
+                .attributes(ImmutableList.of(updatedAttribute))
+                .build();
+
+        ArgumentCaptor<Player> updatedPlayerCaptor = ArgumentCaptor.forClass(Player.class);
+        ArgumentCaptor<ResourceKey> resourceKeyCaptor = ArgumentCaptor.forClass(ResourceKey.class);
+
+        // execute
+        Player updatedPlayer = playerService.updatePlayer(incomingPlayer, existingPlayerInCouchbase, existingPlayerId);
+
+        // assert
+        verify(couchbaseDAO).updateDocument(resourceKeyCaptor.capture(), updatedPlayerCaptor.capture());
+        ResourceKey capturedResourceKey = resourceKeyCaptor.getValue();
+        assertEquals(existingPlayerId, capturedResourceKey.getResourceId());
+
+        Player updatedPlayerInCouchbase = updatedPlayerCaptor.getValue();
+        updatedPlayerInCouchbase.getAttributes().forEach(attribute -> {
+            Attribute existingPlayerAttribute = existingPlayerInCouchbase.getAttributes().stream()
+                    .filter(existingAttribute -> existingAttribute.getName().equals(attribute.getName()))
+                    .findFirst().orElse(null);
+            assertNotNull(existingPlayerAttribute);
+            assertTrue(attribute.getCategory() != null
+                    && PLAYER_ATTRIBUTE_CATEGORIES.contains(attribute.getCategory()));
+            assertTrue(attribute.getGroup() != null
+                    && PLAYER_ATTRIBUTE_GROUPS.contains(attribute.getGroup()));
+            assertEquals(existingPlayerAttribute.getHistory().size() + 1, attribute.getHistory().size());
+            assertEquals(ImmutableList.of(existingPlayerAttribute.getValue(), attribute.getValue()),
+                    attribute.getHistory());
+        });
+        assertNotEquals(existingPlayerInCouchbase.getLastModifiedDate(),
+                updatedPlayerInCouchbase.getLastModifiedDate());
+        assertEquals(CREATED_BY, updatedPlayerInCouchbase.getCreatedBy());
+
+        // TODO: 1/3/2022 consider removing these checks if seems to be redundant 
+        assertEquals(incomingPlayer.getMetadata(), updatedPlayer.getMetadata());
+        assertEquals(incomingPlayer.getRoles(), updatedPlayer.getRoles());
+        assertEquals(incomingPlayer.getAbility(), updatedPlayer.getAbility());
+    }
+
+    /**
+     * given a valid player id, removes the player entity from couchbase
+     */
+    @Test
+    public void deletePlayerRemovesPlayerFromCouchbase() {
+        // setup
+        UUID playerId = UUID.randomUUID();
+        ArgumentCaptor<ResourceKey> resourceKeyCaptor = ArgumentCaptor.forClass(ResourceKey.class);
+
+        // execute
+        playerService.deletePlayer(playerId);
+
+        // assert
+        verify(couchbaseDAO).deleteDocument(resourceKeyCaptor.capture());
+        assertEquals(playerId, resourceKeyCaptor.getValue().getResourceId());
+    }
+
+    /**
+     * given that the couchbase DAO throws a RuntimeException when it cannot find the player entity to remove, the
+     * same exception is propagated and thrown by the resource method as well
+     */
+    @Test(expected = RuntimeException.class)
+    public void deletePlayerWhenPlayerNotFound() {
+        // setup
+        UUID playerId = UUID.randomUUID();
+        ArgumentCaptor<ResourceKey> resourceKeyCaptor = ArgumentCaptor.forClass(ResourceKey.class);
+        doThrow(new RuntimeException("player not found")).when(couchbaseDAO).deleteDocument(any());
+
+        // execute
+        playerService.deletePlayer(playerId);
+
+        // assert
+        verify(couchbaseDAO).deleteDocument(resourceKeyCaptor.capture());
+        assertEquals(playerId, resourceKeyCaptor.getValue().getResourceId());
+    }
+
+    // TODO: 1/3/2022 convert this to a test data creator method using builder pattern
+    private Player getPlayerDataStub(UUID playerId, boolean usePlayerRoles, boolean usePlayerAttributes,
+                                     boolean isExistingPlayer) {
+        Metadata playerMetadata = ImmutableMetadata.builder()
+                .name("fake player name")
+                .country("fake country name")
+                .age(PLAYER_AGE)
+                .club(isExistingPlayer ? "fake club name" : null)
+                .clubLogo(isExistingPlayer ? "fake club logo" : null)
+                .countryLogo(isExistingPlayer ? "fake country logo" : null)
+                .build();
+        Ability playerAbility = ImmutableAbility.builder()
+                .current(CURRENT_PLAYER_ABILITY)
+                .build();
+
+        ImmutablePlayer.Builder playerBuilder = ImmutablePlayer.builder()
+                .metadata(playerMetadata)
+                .ability(playerAbility);
+
+        if (playerId != null) {
+            playerBuilder.id(playerId);
+        }
+
+        if (isExistingPlayer) {
+            Instant currentInstant = Instant.now();
+            Instant olderInstant = currentInstant.minus(1, ChronoUnit.DAYS);
+            playerBuilder.lastModifiedDate(LocalDate.ofInstant(olderInstant, ZoneId.systemDefault()));
+
+            playerBuilder.createdBy(CREATED_BY);
+        }
+
+        if (usePlayerRoles) {
+            Role playerRole = ImmutableRole.builder()
+                    .name("playerRole")
+                    .build();
+            playerBuilder.roles(ImmutableList.of(playerRole));
+        }
+
+        if (usePlayerAttributes) {
+            Attribute playerAttribute = ImmutableAttribute.builder()
+                    .name("sprint speed")
+                    .value(CURRENT_PLAYER_SPRINT_SPEED)
+                    .category(isExistingPlayer ? "Technical" : null)
+                    .group(isExistingPlayer ? "Speed" : null)
+                    .history(isExistingPlayer ? ImmutableList.of(CURRENT_PLAYER_SPRINT_SPEED) : ImmutableList.of())
+                    .build();
+
+            playerBuilder.attributes(ImmutableList.of(playerAttribute));
+        }
+        return playerBuilder.clubId(UUID.randomUUID()).build();
+    }
+}

--- a/dashboard-ui/src/clients/DashboardClient.js
+++ b/dashboard-ui/src/clients/DashboardClient.js
@@ -1,8 +1,13 @@
 import fetchDataFromEndpoint from './utils';
 import { httpStatus } from '../utils';
 
-export const createNewPlayer = async ({ newPlayerData, authToken }) => {
-    const res = await fetchDataFromEndpoint('player', 'POST', { Authorization: `BEARER ${authToken}`}, newPlayerData);
+export const createNewPlayer = async ({ newPlayerData, clubId, authToken }) => {
+    const res = await fetchDataFromEndpoint(
+        'player',
+        'POST',
+        { Authorization: `BEARER ${authToken}` },
+        { clubId, ...newPlayerData }
+    );
     if (res.ok) {
         return await res.json();
     } else if (res.status === httpStatus.BAD_STATUS) {

--- a/dashboard-ui/src/clients/DashboardClient.js
+++ b/dashboard-ui/src/clients/DashboardClient.js
@@ -3,7 +3,7 @@ import { httpStatus } from '../utils';
 
 export const createNewPlayer = async ({ newPlayerData, clubId, authToken }) => {
     const res = await fetchDataFromEndpoint(
-        'player',
+        'players',
         'POST',
         { Authorization: `BEARER ${authToken}` },
         { clubId, ...newPlayerData }

--- a/dashboard-ui/src/components/DialogForm.js
+++ b/dashboard-ui/src/components/DialogForm.js
@@ -37,10 +37,10 @@ export default function DialogForm({
                 )}
                 <Button
                     disabled={submitStatus !== formSubmission.READY}
-                    onClick={activeStep < numSteps ? handleNext : handleSubmit}
+                    onClick={numSteps === 1 || activeStep === numSteps ? handleSubmit : handleNext}
                     color='primary'
                 >
-                    {activeStep < numSteps ? 'Next' : 'Submit'}
+                    {numSteps === 1 || activeStep === numSteps ? 'Submit' : 'Next'}
                 </Button>
             </DialogActions>
         </Dialog>

--- a/dashboard-ui/src/hooks/useAddNewPlayer.js
+++ b/dashboard-ui/src/hooks/useAddNewPlayer.js
@@ -2,10 +2,12 @@ import { useMutation, useQueryClient } from 'react-query';
 
 import { createNewPlayer } from '../clients/DashboardClient';
 import { useUserAuth } from '../context/authProvider';
+import { useCurrentClub } from '../context/clubProvider';
 import { queryKeys } from '../utils';
 
 export default function () {
     const { authData } = useUserAuth();
+    const { currentClubId } = useCurrentClub();
     const queryClient = useQueryClient();
 
     const { mutateAsync } = useMutation(createNewPlayer, {
@@ -17,7 +19,7 @@ export default function () {
     return {
         addNewPlayerAction: async newPlayerData => {
             try {
-                await mutateAsync({ newPlayerData, authToken: authData.id });
+                await mutateAsync({ newPlayerData, clubId: currentClubId, authToken: authData.id });
             } catch (err) {
                 if (err instanceof Error) {
                     return err.message;

--- a/dashboard-ui/src/hooks/useAddNewPlayer.js
+++ b/dashboard-ui/src/hooks/useAddNewPlayer.js
@@ -18,8 +18,18 @@ export default function () {
 
     return {
         addNewPlayerAction: async newPlayerData => {
+            const { technicalAttributes, mentalAttributes, physicalAttributes, role, ...rest } = newPlayerData;
+            const attributes = [
+                ...Object.entries(technicalAttributes).map(([key, value]) => ({ name: key, value })),
+                ...Object.entries(physicalAttributes).map(([key, value]) => ({ name: key, value })),
+                ...Object.entries(mentalAttributes).map(([key, value]) => ({ name: key, value }))
+            ];
             try {
-                await mutateAsync({ newPlayerData, clubId: currentClubId, authToken: authData.id });
+                await mutateAsync({
+                    newPlayerData: { attributes, roles: [role], ...rest },
+                    clubId: currentClubId,
+                    authToken: authData.id
+                });
             } catch (err) {
                 if (err instanceof Error) {
                     return err.message;

--- a/dashboard-ui/src/hooks/useForm.js
+++ b/dashboard-ui/src/hooks/useForm.js
@@ -5,9 +5,11 @@ import { capitalizeLabel, convertCamelCaseToSnakeCase, formSubmission } from '..
 const getEmptyFieldValidation = fieldName =>
     `${capitalizeLabel(convertCamelCaseToSnakeCase(fieldName))} cannot be empty!`;
 const validateEmail = email => /\S+@\S+\.\S+/.test(email);
+const validatePlayerAge = playerAge => parseInt(playerAge) >= 15 && parseInt(playerAge) <= 50;
 
 const validateInput = (name, value, formData) => {
     if (typeof value === 'string' && !value.trim()) return getEmptyFieldValidation(name);
+    if (name === 'age' && !validatePlayerAge(value)) return 'Player age must be between 15 and 50 years!';
     if (name === 'email' && !validateEmail(value)) return 'Email format is incorrect!';
     if (name === 'newPassword' || name === 'confirmedPassword') {
         if (value.length < 6 || value.length > 12) return 'Password must be between 6 and 12 characters';

--- a/dashboard-ui/src/mocks/handlers.js
+++ b/dashboard-ui/src/mocks/handlers.js
@@ -68,7 +68,7 @@ export const getClubHandlers = (baseUrl = '*', clubIdFragment = ':clubId') => {
 
 export const getPlayerHandlers = (baseUrl = '*') => {
     return [
-        rest.post(`${baseUrl}/player`, (req, res, ctx) => {
+        rest.post(`${baseUrl}/players`, (req, res, ctx) => {
             return res(ctx.status(201), ctx.json({ id: 'new-player-id', ...req.body }));
         })
     ];

--- a/dashboard-ui/src/views/SquadHubView.js
+++ b/dashboard-ui/src/views/SquadHubView.js
@@ -31,6 +31,7 @@ const buildHeaderDataForSquadTable = headerNames =>
             type: squadTableHeaderDisplayTypeMap[name]
         }));
 
+// TODO: move this into a hook
 const buildRowDataForSquadTable = players => {
     return players.map(player => {
         const keys = Object.keys(player);
@@ -173,7 +174,7 @@ export default function SquadHubView({ players, addPlayerWidget }) {
 SquadHubView.propTypes = {
     players: PropTypes.arrayOf(
         PropTypes.shape({
-            playerId: PropTypes.number,
+            playerId: PropTypes.string,
             name: PropTypes.string,
             nationality: PropTypes.string,
             role: PropTypes.string,

--- a/dashboard-ui/src/widgets/AddPlayerForm.js
+++ b/dashboard-ui/src/widgets/AddPlayerForm.js
@@ -261,7 +261,7 @@ const PlayerRoleForm = ({ newPlayerRoleData, newPlayerRoleValidations, handleCha
         <>
             <TextField
                 name='name'
-                label='Select Nationality'
+                label='Select Role'
                 required
                 id='name'
                 margin='normal'

--- a/dashboard-ui/src/widgets/AddPlayerForm.js
+++ b/dashboard-ui/src/widgets/AddPlayerForm.js
@@ -59,7 +59,7 @@ export const getStepper = activeStep => {
 };
 
 export const getAddPlayerFormSchema = () => ({
-    metadata: { name: '', age: '0', country: '' },
+    metadata: { name: '', age: '', country: '' },
     role: { name: '', associatedAttributes: [] },
     technicalAttributes: {
         freekickAccuracy: '0',
@@ -146,12 +146,14 @@ const PlayerMetadataForm = ({ newPlayerMetadata, newPlayerMetadataValidations, h
                 helperText={newPlayerMetadataValidations.name}
             />
             <TextField
+                placeholder='Please enter age between 15 and 50'
                 name='age'
                 label='Age'
                 required
                 id='age'
                 type='number'
                 margin='normal'
+                inputProps={{ min: 15, max: 50 }}
                 fullWidth
                 value={newPlayerMetadata.age}
                 onChange={e => handleChangeFn(e)}

--- a/dashboard-ui/src/widgets/AddPlayerForm.js
+++ b/dashboard-ui/src/widgets/AddPlayerForm.js
@@ -18,11 +18,11 @@ import { capitalizeLabel, nationalityFlagMap } from '../utils';
 
 // TODO: build this from the server lookup for roles and countries instead of hard-coding it here
 const roles = [
-    { value: 'defensiveCentralMidfielder', label: 'Defensive Central Midfielder' },
-    { value: 'falseNine', label: 'False Nine' },
-    { value: 'sweeperKeeper', label: 'Sweeper Keeper' },
+    { value: 'defensive central midfielder', label: 'Defensive Central Midfielder' },
+    { value: 'false nine', label: 'False Nine' },
+    { value: 'sweeper keeper', label: 'Sweeper Keeper' },
     { value: 'regista', label: 'Regista' },
-    { value: 'insideForward', label: 'Inside Forward' }
+    { value: 'inside forward', label: 'Inside Forward' }
 ];
 
 // TODO: build this from server lookup; dummy data for now


### PR DESCRIPTION
In this PR, made changes to the Player model and business logic to match what is expected in the request body when creating a new player. The PR also includes some refactoring to make creating test data easier and abstract business logic behind a service layer.
Also, fixed some bugs related to the add player form.