### PR TITLE
Add club service layer

### DIFF
--- a/dashboard-server/src/main/java/com/footballstatsdashboard/FootballDashboardApplication.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/FootballDashboardApplication.java
@@ -22,6 +22,7 @@ import com.footballstatsdashboard.resources.ClubResource;
 import com.footballstatsdashboard.resources.MatchPerformanceResource;
 import com.footballstatsdashboard.resources.PlayerResource;
 import com.footballstatsdashboard.resources.UserResource;
+import com.footballstatsdashboard.services.ClubService;
 import com.footballstatsdashboard.services.PlayerService;
 import io.dropwizard.Application;
 import io.dropwizard.auth.AuthDynamicFeature;
@@ -99,12 +100,13 @@ public class FootballDashboardApplication extends Application<FootballDashboardC
                 new AuthTokenKeyProvider(), environment.getObjectMapper());
 
         // setup services
+        ClubService clubService = new ClubService(clubCouchbaseDAO);
         PlayerService playerService = new PlayerService(playerCouchbaseDAO);
 
         // setup resources
         environment.jersey().register(new UserResource(userCouchbaseDAO, authTokenDAO));
         environment.jersey().register(new PlayerResource(playerService, clubCouchbaseDAO));
-        environment.jersey().register(new ClubResource(clubCouchbaseDAO));
+        environment.jersey().register(new ClubResource(clubService));
         environment.jersey().register(new MatchPerformanceResource(matchPerformanceDAO));
 
         // Register OAuth authentication

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/FootballDashboardApplication.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/FootballDashboardApplication.java
@@ -105,7 +105,7 @@ public class FootballDashboardApplication extends Application<FootballDashboardC
 
         // setup resources
         environment.jersey().register(new UserResource(userCouchbaseDAO, authTokenDAO));
-        environment.jersey().register(new PlayerResource(playerService, clubCouchbaseDAO));
+        environment.jersey().register(new PlayerResource(playerService, clubService));
         environment.jersey().register(new ClubResource(clubService));
         environment.jersey().register(new MatchPerformanceResource(matchPerformanceDAO));
 

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/resources/PlayerResource.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/resources/PlayerResource.java
@@ -3,8 +3,7 @@ package com.footballstatsdashboard.resources;
 import com.footballstatsdashboard.api.model.Player;
 import com.footballstatsdashboard.api.model.User;
 import com.footballstatsdashboard.api.model.club.Club;
-import com.footballstatsdashboard.db.CouchbaseDAO;
-import com.footballstatsdashboard.db.key.ResourceKey;
+import com.footballstatsdashboard.services.ClubService;
 import com.footballstatsdashboard.services.PlayerService;
 import io.dropwizard.auth.Auth;
 import org.eclipse.jetty.http.HttpStatus;
@@ -38,11 +37,11 @@ public class PlayerResource {
     private static final Logger LOGGER = LoggerFactory.getLogger(PlayerResource.class);
 
     private final PlayerService playerService;
-    private final CouchbaseDAO<ResourceKey> clubCouchbaseDAO;
+    private final ClubService clubService;
 
-    public PlayerResource(PlayerService playerService, CouchbaseDAO<ResourceKey> clubCouchbaseDAO) {
+    public PlayerResource(PlayerService playerService, ClubService clubService) {
         this.playerService = playerService;
-        this.clubCouchbaseDAO = clubCouchbaseDAO;
+        this.clubService = clubService;
     }
 
     @GET
@@ -74,9 +73,7 @@ public class PlayerResource {
         }
 
         // fetch details of club the incoming player belongs to
-        // TODO: 1/5/2022 fetch club using club service when it is ready, instead of directly using DAO
-        ResourceKey resourceKeyForClub = new ResourceKey(incomingPlayer.getClubId());
-        Club clubDataForNewPlayer = this.clubCouchbaseDAO.getDocument(resourceKeyForClub, Club.class);
+        Club clubDataForNewPlayer = this.clubService.getClub(incomingPlayer.getClubId());
 
         Player newPlayer = this.playerService.createPlayer(incomingPlayer, clubDataForNewPlayer, user.getEmail());
 

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
@@ -1,0 +1,70 @@
+package com.footballstatsdashboard.services;
+
+import com.footballstatsdashboard.api.model.club.Club;
+import com.footballstatsdashboard.api.model.club.ImmutableClub;
+import com.footballstatsdashboard.api.model.club.SquadPlayer;
+import com.footballstatsdashboard.db.ClubDAO;
+import com.footballstatsdashboard.db.key.ResourceKey;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+public class ClubService {
+    private final ClubDAO<ResourceKey> clubDAO;
+
+    public ClubService(ClubDAO<ResourceKey> clubDAO) {
+        this.clubDAO = clubDAO;
+    }
+
+    public Club getClub(UUID clubId) {
+        ResourceKey resourceKey = new ResourceKey(clubId);
+        return this.clubDAO.getDocument(resourceKey, Club.class);
+    }
+
+    public Club createClub(Club incomingClub, UUID userId, String createdBy) {
+        LocalDate currentDate = LocalDate.now();
+        Club newClub = ImmutableClub.builder()
+                .from(incomingClub)
+                .userId(userId)
+                .createdDate(currentDate)
+                .lastModifiedDate(currentDate)
+                .createdBy(createdBy)
+                .build();
+
+        ResourceKey resourceKey = new ResourceKey(newClub.getId());
+        this.clubDAO.insertDocument(resourceKey, newClub);
+
+        return newClub;
+    }
+
+    public Club updateClub(Club incomingClub, Club existingClub, UUID existingClubId) {
+        Club updatedClub = ImmutableClub.builder()
+                .from(existingClub)
+                .name(incomingClub.getName())
+                .income(incomingClub.getIncome())
+                .expenditure(incomingClub.getExpenditure())
+                .transferBudget(incomingClub.getTransferBudget())
+                .wageBudget(incomingClub.getWageBudget())
+                .lastModifiedDate(LocalDate.now())
+                .build();
+
+        ResourceKey resourceKey = new ResourceKey(existingClubId);
+        this.clubDAO.updateDocument(resourceKey, updatedClub);
+
+        return updatedClub;
+    }
+
+    public void deleteClub(UUID clubId) {
+        ResourceKey resourceKey = new ResourceKey(clubId);
+        this.clubDAO.deleteDocument(resourceKey);
+    }
+
+    public List<Club> getClubsByUserId(UUID userId) {
+        return this.clubDAO.getClubsByUserId(userId);
+    }
+
+    public List<SquadPlayer> getSquadPlayers(UUID clubId) {
+        return this.clubDAO.getPlayersInClub(clubId);
+    }
+}

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/ClubDataProvider.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/ClubDataProvider.java
@@ -1,0 +1,123 @@
+package com.footballstatsdashboard;
+
+import com.footballstatsdashboard.api.model.club.Club;
+import com.footballstatsdashboard.api.model.club.ImmutableClub;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public final class ClubDataProvider {
+    private static final String CREATED_BY = "fake email";
+    private static final String DEFAULT_CLUB_NAME = "fake club name";
+    private static final int NUMBER_OF_CLUBS = 3;
+
+    private ClubDataProvider() { }
+    /**
+     * Helps in building a club entity according to the needs of a test
+     */
+    public static final class ClubBuilder {
+        private boolean isExistingClub = false;
+        private String customClubName = null;
+        private UUID existingUserId = null;
+        private final ImmutableClub.Builder baseClub = ImmutableClub.builder();
+
+        private ClubBuilder() { }
+
+        public static ClubBuilder builder() {
+            return new ClubBuilder();
+        }
+
+        public ClubBuilder isExisting(boolean isExisting) {
+            this.isExistingClub = isExisting;
+            return this;
+        }
+
+        public ClubBuilder withId(UUID clubId) {
+            baseClub.id(clubId);
+            return this;
+        }
+
+        public ClubBuilder customClubName(String clubName) {
+            this.customClubName = clubName;
+            return this;
+        }
+
+        public ClubBuilder existingUserId(UUID userId) {
+            this.existingUserId = userId;
+            return this;
+        }
+
+        public Club build() {
+            // add some house-keeping fields if it is an existing club
+            if (isExistingClub) {
+                Instant currentInstant = Instant.now();
+                Instant olderInstant = currentInstant.minus(1, ChronoUnit.DAYS);
+
+                baseClub.lastModifiedDate(LocalDate.ofInstant(olderInstant, ZoneId.systemDefault()));
+                baseClub.createdBy(CREATED_BY);
+                baseClub.userId(this.existingUserId != null ? existingUserId : UUID.randomUUID());
+            }
+
+            // add the required fields which don't require dynamic values in test suites and build the club entity
+            return this.baseClub
+                    .name(this.customClubName != null ? this.customClubName : DEFAULT_CLUB_NAME)
+                    .expenditure(new BigDecimal("1000"))
+                    .income(new BigDecimal("2000"))
+                    .transferBudget(new BigDecimal("500"))
+                    .wageBudget(new BigDecimal("200"))
+                    .build();
+        }
+    }
+
+    /**
+     * Helps in building a club entity from an existing one and allows overriding certain properties according to the
+     * needs of a test
+     */
+    public static final class ModifiedClubBuilder {
+        private ImmutableClub.Builder baseClub = ImmutableClub.builder();
+
+        private ModifiedClubBuilder() { }
+
+        public static ModifiedClubBuilder builder() {
+            return new ModifiedClubBuilder();
+        }
+
+        public ModifiedClubBuilder from(Club club) {
+            baseClub = ImmutableClub.builder().from(club);
+            return this;
+        }
+
+        public ModifiedClubBuilder withUpdatedWageBudget(BigDecimal newWageBudget) {
+            baseClub.wageBudget(newWageBudget);
+            return this;
+        }
+
+        public Club build() {
+            return this.baseClub
+                    .lastModifiedDate(LocalDate.now())
+                    .build();
+        }
+    }
+
+    /**
+     * Leverage the ClubBuilder to create a fixed number of Club entities associated with the user whose ID is passed in
+     * @param userId ID of the user whose associated club data needs to be fetched
+     * @return a fixed number of Club entities associated with the user whose ID passed in
+     */
+    public static List<Club> getAllClubsForUser(UUID userId) {
+        return IntStream.range(0, NUMBER_OF_CLUBS).mapToObj(i ->
+                ClubBuilder.builder()
+                        .isExisting(true)
+                        .existingUserId(userId)
+                        .customClubName(DEFAULT_CLUB_NAME + i)
+                        .build()
+        ).collect(Collectors.toList());
+    }
+}

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/ClubDataProvider.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/ClubDataProvider.java
@@ -19,6 +19,7 @@ public final class ClubDataProvider {
     private static final int NUMBER_OF_CLUBS = 3;
 
     private ClubDataProvider() { }
+
     /**
      * Helps in building a club entity according to the needs of a test
      */

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/PlayerDataProvider.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/PlayerDataProvider.java
@@ -21,7 +21,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class PlayerDataProvider {
-
     private static final int PLAYER_AGE = 27;
     private static final int CURRENT_PLAYER_ABILITY = 19;
     private static final int CURRENT_PLAYER_SPRINT_SPEED = 85;
@@ -29,9 +28,13 @@ public class PlayerDataProvider {
     private static final int CURRENT_PLAYER_COMPOSURE = 75;
     private static final String CREATED_BY = "fake email";
 
+    /**
+     * Helps in building a player entity according to the needs of a test
+     */
     public static final class PlayerBuilder {
         private boolean isExistingPlayer = false;
         private final ImmutablePlayer.Builder basePlayer = ImmutablePlayer.builder().clubId(UUID.randomUUID());
+
         private PlayerBuilder() { }
 
         public static PlayerBuilder builder() {
@@ -118,9 +121,14 @@ public class PlayerDataProvider {
         }
     }
 
+    /**
+     * Helps in building a player entity from an existing one and allows overriding certain properties according to the
+     * needs of a test
+     */
     public static final class ModifiedPlayerBuilder {
         private Player playerReference;
         private ImmutablePlayer.Builder basePlayer = ImmutablePlayer.builder();
+
         private ModifiedPlayerBuilder() { }
 
         public static ModifiedPlayerBuilder builder() {
@@ -183,7 +191,9 @@ public class PlayerDataProvider {
         }
 
         public Player build() {
-            return this.basePlayer.build();
+            return this.basePlayer
+                    .lastModifiedDate(LocalDate.now())
+                    .build();
         }
     }
 }

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/services/ClubServiceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/services/ClubServiceTest.java
@@ -1,0 +1,275 @@
+package com.footballstatsdashboard.services;
+
+import com.footballstatsdashboard.api.model.club.Club;
+import com.footballstatsdashboard.api.model.club.ImmutableClub;
+import com.footballstatsdashboard.api.model.club.ImmutableSquadPlayer;
+import com.footballstatsdashboard.api.model.club.SquadPlayer;
+import com.footballstatsdashboard.db.ClubDAO;
+import com.footballstatsdashboard.db.key.ResourceKey;
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ClubServiceTest {
+    private static final String USER_EMAIL = "fake email";
+    private static final int CURRENT_PLAYER_ABILITY = 19;
+
+    private UUID userId;
+    private ClubService clubService;
+
+    @Mock
+    private ClubDAO<ResourceKey> clubDAO;
+
+    /**
+     * set up test data before each test case is run
+     */
+    @Before
+    public void initialize() {
+        MockitoAnnotations.openMocks(this);
+
+        userId = UUID.randomUUID();
+        clubService = new ClubService(clubDAO);
+    }
+
+    /**
+     * given a valid club id, tests that the club entity is successfully fetched from couchbase server and returned
+     * in the response
+     */
+    @Test
+    public void getClubFetchesClubFromCouchbase() {
+        // setup
+        UUID clubId = UUID.randomUUID();
+        Club clubFromCouchbase = getClubDataStub(clubId, userId, false, null);
+        when(clubDAO.getDocument(any(), any())).thenReturn(clubFromCouchbase);
+
+        // execute
+        Club club = clubService.getClub(clubId);
+
+        // assert
+        verify(clubDAO).getDocument(any(), any());
+
+        assertEquals(clubId, club.getId());
+        assertNotNull(club.getUserId());
+        assertEquals(userId, club.getUserId());
+    }
+
+    /**
+     * given a runtime exception is thrown by couchbase DAO when club entity is not found, verifies that the same
+     * exception is thrown by `getClub` resource method as well
+     */
+    @Test(expected = RuntimeException.class)
+    public void getClubWhenClubNotFoundInCouchbase() {
+        // setup
+        UUID invalidClubId = UUID.randomUUID();
+        when(clubDAO.getDocument(any(), any()))
+                .thenThrow(new RuntimeException("Unable to find document with ID: " + invalidClubId));
+
+        // execute
+        clubService.getClub(invalidClubId);
+
+        // assert
+        verify(clubDAO).getDocument(any(), any());
+    }
+
+    /**
+     * given a valid club entity in the request, tests that the internal fields are set correctly on the entity and
+     * persisted in couchbase
+     */
+    @Test
+    public void createClubPersistsClubInCouchbase() {
+        // setup
+        Club incomingClub = getClubDataStub(null, null, false, null);
+        ArgumentCaptor<Club> newClubCaptor = ArgumentCaptor.forClass(Club.class);
+
+        // execute
+        Club createdClub = clubService.createClub(incomingClub, userId, USER_EMAIL);
+
+        // assert
+        verify(clubDAO).insertDocument(any(), newClubCaptor.capture());
+        Club newClub = newClubCaptor.getValue();
+        assertEquals(createdClub, newClub);
+
+        assertEquals(incomingClub.getId(), createdClub.getId());
+
+        // assertions for general house-keeping fields
+        assertNotNull(createdClub.getCreatedDate());
+        assertNotNull(createdClub.getLastModifiedDate());
+        assertEquals(USER_EMAIL, createdClub.getCreatedBy());
+        assertEquals(userId, createdClub.getUserId());
+    }
+
+    /**
+     * given a valid club entity in the request, tests that an updated club entity with update internal fields is
+     * upserted in couchbase
+     */
+    @Test
+    public void updateClubUpdatesClubInCouchbase() {
+        // setup
+        UUID existingClubId = UUID.randomUUID();
+        Club existingClubInCouchbase = getClubDataStub(existingClubId, userId, true, null);
+
+        BigDecimal updatedWageBudget = existingClubInCouchbase.getWageBudget().add(new BigDecimal("100"));
+        Club incomingClub = ImmutableClub.builder()
+                .from(getClubDataStub(existingClubId, null, false, null))
+                .wageBudget(updatedWageBudget)
+                .build();
+        when(clubDAO.getDocument(any(), any())).thenReturn(existingClubInCouchbase);
+
+        ArgumentCaptor<Club> updatedClubCaptor = ArgumentCaptor.forClass(Club.class);
+
+        // execute
+        Club updatedClub = clubService.updateClub(incomingClub, existingClubInCouchbase, existingClubId);
+
+        // assert
+        verify(clubDAO).updateDocument(any(), updatedClubCaptor.capture());
+        Club clubToBeUpdatedInCouchbase = updatedClubCaptor.getValue();
+        assertEquals(updatedClub, clubToBeUpdatedInCouchbase);
+
+        assertEquals(existingClubInCouchbase.getId(), updatedClub.getId());
+        assertEquals(updatedWageBudget, updatedClub.getWageBudget());
+
+        // assertions for general house-keeping fields
+        assertEquals(USER_EMAIL, updatedClub.getCreatedBy());
+        assertEquals(userId, updatedClub.getUserId());
+        assertEquals(LocalDate.now(), updatedClub.getLastModifiedDate());
+    }
+
+    /**
+     * given a valid club ID, removes the club entity from couchbase
+     */
+    @Test
+    public void deleteClubRemovesClubFromCouchbase() {
+        // setup
+        UUID clubId = UUID.randomUUID();
+        ArgumentCaptor<ResourceKey> resourceKeyCaptor = ArgumentCaptor.forClass(ResourceKey.class);
+
+        // execute
+        clubService.deleteClub(clubId);
+
+        // assert
+        verify(clubDAO).deleteDocument(resourceKeyCaptor.capture());
+        ResourceKey capturedResourceKey = resourceKeyCaptor.getValue();
+        assertEquals(clubId, capturedResourceKey.getResourceId());
+    }
+
+    /**
+     * given a valid user entity as the auth principal, tests that all clubs associated with the user is fetched from
+     * couchbase
+     */
+    @Test
+    public void getClubsByUserIdFetchesAllClubsForUser() {
+        // setup
+        int numberOfClubs = 2;
+        List<Club> mockClubData = IntStream.range(0, numberOfClubs).mapToObj(idx ->
+                getClubDataStub(null, userId, true, "fake club name " + idx)
+        ).collect(Collectors.toList());
+        when(clubDAO.getClubsByUserId(any())).thenReturn(mockClubData);
+
+        // execute
+        List<Club> clubList = clubService.getClubsByUserId(userId);
+
+        // assert
+        verify(clubDAO).getClubsByUserId(eq(userId));
+        assertFalse(clubList.isEmpty());
+
+        for (int idx = 0; idx < clubList.size(); idx++) {
+            assertEquals(userId, clubList.get(idx).getUserId());
+            assertTrue(clubList.get(idx).getName().contains(String.valueOf(idx)));
+        }
+    }
+
+    /**
+     * given a valid user entity as the auth principal but no there are no club entities associated with it, tests that
+     * an empty list is returned
+     */
+    @Test
+    public void getClubsByUserIdReturnsEmptyListWhenNoClubsAreAssociatedWithUser() {
+        // setup
+        List<Club> mockClubData = new ArrayList<>();
+        when(clubDAO.getClubsByUserId(any())).thenReturn(mockClubData);
+
+        // execute
+        List<Club> clubList = clubService.getClubsByUserId(userId);
+
+        // assert
+        verify(clubDAO).getClubsByUserId(eq(userId));
+        assertTrue(clubList.isEmpty());
+    }
+
+    /**
+     * given a valid club ID, fetches player data for all players associated with the club from couchbase
+     */
+    @Test
+    public void getSquadPlayersFetchesPlayersFromCouchbase() {
+        // setup
+        UUID clubId = UUID.randomUUID();
+        ImmutableSquadPlayer expectedSquadPlayer = ImmutableSquadPlayer.builder()
+                .name("fake player name")
+                .country("fake player country")
+                .role("fake player role")
+                .currentAbility(CURRENT_PLAYER_ABILITY)
+                .recentForm(new ArrayList<>())
+                .playerId(UUID.randomUUID())
+                .build();
+        when(clubDAO.getPlayersInClub(eq(clubId))).thenReturn(ImmutableList.of(expectedSquadPlayer));
+
+        // execute
+        List<SquadPlayer> squadPlayerList = clubService.getSquadPlayers(clubId);
+
+        // assert
+        verify(clubDAO).getPlayersInClub(eq(clubId));
+
+        assertFalse(squadPlayerList.isEmpty());
+        squadPlayerList.forEach(squadPlayer -> {
+            assertNotNull(squadPlayer);
+            assertEquals(expectedSquadPlayer, squadPlayer);
+        });
+    }
+
+    private Club getClubDataStub(UUID clubId, UUID userID, boolean isExisting, String clubName) {
+        ImmutableClub.Builder clubBuilder = ImmutableClub.builder()
+                .name(clubName != null ? clubName : "fake club name")
+                .expenditure(new BigDecimal("1000"))
+                .income(new BigDecimal("2000"))
+                .transferBudget(new BigDecimal("500"))
+                .wageBudget(new BigDecimal("200"));
+
+        if (clubId != null) clubBuilder.id(clubId);
+
+        if (userID != null) {
+            clubBuilder.userId(userID);
+            clubBuilder.createdBy(USER_EMAIL);
+        }
+
+        if (isExisting) {
+            Instant currentInstant = Instant.now();
+            Instant olderInstant = currentInstant.minus(1, ChronoUnit.DAYS);
+            clubBuilder.lastModifiedDate(LocalDate.ofInstant(olderInstant, ZoneId.systemDefault()));
+        }
+
+        return clubBuilder.build();
+    }
+}

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/services/PlayerServiceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/services/PlayerServiceTest.java
@@ -1,11 +1,11 @@
 package com.footballstatsdashboard.services;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.footballstatsdashboard.ClubDataProvider;
 import com.footballstatsdashboard.PlayerDataProvider;
 import com.footballstatsdashboard.api.model.CountryCodeMetadata;
 import com.footballstatsdashboard.api.model.Player;
 import com.footballstatsdashboard.api.model.club.Club;
-import com.footballstatsdashboard.api.model.club.ImmutableClub;
 import com.footballstatsdashboard.api.model.player.Attribute;
 import com.footballstatsdashboard.api.model.player.Metadata;
 import com.footballstatsdashboard.core.utils.FixtureLoader;
@@ -20,7 +20,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 
@@ -113,12 +112,11 @@ public class PlayerServiceTest {
                 .withAttributes()
                 .build();
         ArgumentCaptor<Player> newPlayerCaptor = ArgumentCaptor.forClass(Player.class);
-        Club existingClub = ImmutableClub.builder()
-                .name("fake club name")
-                .expenditure(new BigDecimal("1000"))
-                .income(new BigDecimal("2000"))
-                .transferBudget(new BigDecimal("500"))
-                .wageBudget(new BigDecimal("200"))
+
+        Club existingClub = ClubDataProvider.ClubBuilder.builder()
+                .isExisting(true)
+                .existingUserId(UUID.randomUUID())
+                .withId(UUID.randomUUID())
                 .build();
 
         // execute


### PR DESCRIPTION
In this PR, made the following changes -

- Created a service class for club entity and moved business logic inside it
- Created a data provider for club related tests
- Updated tests for resource class and added tests for service class by leveraging the test data provider
- Updated player creation logic to use the club service instead of the club DAO