### PR TITLE
Update club entity to incorporate manager funds and track income/expenditure history

### DIFF
--- a/dashboard-server/src/main/java/com/footballstatsdashboard/FootballDashboardApplication.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/FootballDashboardApplication.java
@@ -5,7 +5,8 @@ import com.footballstatsdashboard.client.couchbase.CouchbaseClientManager;
 import com.footballstatsdashboard.client.couchbase.config.ClusterConfiguration;
 import com.footballstatsdashboard.core.service.auth.CustomAuthenticator;
 import com.footballstatsdashboard.core.service.auth.CustomAuthorizer;
-import com.footballstatsdashboard.core.utils.PlayerInternalModule;
+import com.footballstatsdashboard.core.utils.DashboardInternalModule;
+import com.footballstatsdashboard.core.utils.DashboardReadonlyModule;
 import com.footballstatsdashboard.db.AuthTokenDAO;
 import com.footballstatsdashboard.db.ClubDAO;
 import com.footballstatsdashboard.db.CouchbaseDAO;
@@ -59,8 +60,9 @@ public class FootballDashboardApplication extends Application<FootballDashboardC
 
     @Override
     public void run(final FootballDashboardConfiguration configuration, final Environment environment) {
-
-        environment.getObjectMapper().registerModule(new PlayerInternalModule());
+        // initialize serialization modules
+        environment.getObjectMapper().registerModule(new DashboardInternalModule());
+        environment.getObjectMapper().registerModule(new DashboardReadonlyModule());
 
         // setup couchbase cluster and bucket
         CouchbaseClientManager couchbaseClientManager = new CouchbaseClientManager(getName(), environment,

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/Club.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/Club.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.footballstatsdashboard.api.model.club.Expenditure;
+import com.footballstatsdashboard.api.model.club.Income;
 import com.footballstatsdashboard.core.utils.InternalField;
 import org.immutables.value.Value;
 
@@ -52,13 +54,15 @@ public interface Club {
      * club's income in a year
      */
     @Valid
-    BigDecimal getIncome();
+    @Nullable
+    Income getIncome();
 
     /**
      * club's expenditure in a year
      */
     @Valid
-    BigDecimal getExpenditure();
+    @Nullable
+    Expenditure getExpenditure();
 
     /**
      * ID of user the club belongs to

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/Club.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/Club.java
@@ -1,4 +1,4 @@
-package com.footballstatsdashboard.api.model.club;
+package com.footballstatsdashboard.api.model;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/Club.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/Club.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import com.footballstatsdashboard.api.model.club.Expenditure;
 import com.footballstatsdashboard.api.model.club.Income;
+import com.footballstatsdashboard.api.model.club.ManagerFunds;
 import com.footballstatsdashboard.core.utils.InternalField;
 import org.immutables.value.Value;
 
@@ -37,6 +38,12 @@ public interface Club {
      */
     @Valid
     String getName();
+
+    /**
+     * funds allocated to the manager from the club's finances
+     */
+    @Valid
+    ManagerFunds getManagerFunds();
 
     /**
      * club's yearly transfer budget

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/club/Expenditure.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/club/Expenditure.java
@@ -1,0 +1,30 @@
+package com.footballstatsdashboard.api.model.club;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Size;
+import java.math.BigDecimal;
+import java.util.List;
+
+@Value.Immutable
+@JsonSerialize
+@JsonDeserialize(as = ImmutableExpenditure.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Value.Style(jdkOnly = true) // Required if the below entity will be used in a Map, List, Set or any other collection
+public interface Expenditure {
+    /**
+     * current value of expenditure
+     */
+    @Valid BigDecimal getCurrent();
+
+    /**
+     * list of all values of expenditure entity in the past, including the current value
+     */
+    @Valid
+    @Size(min = 1)
+    List<BigDecimal> getHistory();
+}

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/club/Expenditure.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/club/Expenditure.java
@@ -3,6 +3,7 @@ package com.footballstatsdashboard.api.model.club;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.footballstatsdashboard.core.utils.Readonly;
 import org.immutables.value.Value;
 
 import javax.validation.Valid;
@@ -25,6 +26,7 @@ public interface Expenditure {
      * list of all values of expenditure entity in the past, including the current value
      */
     @Valid
+    @Readonly
     @Size(min = 1)
     List<BigDecimal> getHistory();
 }

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/club/Income.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/club/Income.java
@@ -1,0 +1,30 @@
+package com.footballstatsdashboard.api.model.club;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Size;
+import java.math.BigDecimal;
+import java.util.List;
+
+@Value.Immutable
+@JsonSerialize
+@JsonDeserialize(as = ImmutableIncome.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Value.Style(jdkOnly = true) // Required if the below entity will be used in a Map, List, Set or any other collection
+public interface Income {
+    /**
+     * current value of income
+     */
+    @Valid BigDecimal getCurrent();
+
+    /**
+     * list of all values of income entity in the past, including the current value
+     */
+    @Valid
+    @Size(min = 1)
+    List<BigDecimal> getHistory();
+}

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/club/Income.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/club/Income.java
@@ -3,8 +3,10 @@ package com.footballstatsdashboard.api.model.club;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.footballstatsdashboard.core.utils.Readonly;
 import org.immutables.value.Value;
 
+import javax.annotation.Nullable;
 import javax.validation.Valid;
 import javax.validation.constraints.Size;
 import java.math.BigDecimal;
@@ -25,6 +27,8 @@ public interface Income {
      * list of all values of income entity in the past, including the current value
      */
     @Valid
+    @Nullable
+    @Readonly
     @Size(min = 1)
     List<BigDecimal> getHistory();
 }

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/club/ManagerFunds.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/club/ManagerFunds.java
@@ -1,0 +1,34 @@
+package com.footballstatsdashboard.api.model.club;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.footballstatsdashboard.core.utils.Readonly;
+import org.immutables.value.Value;
+
+import javax.annotation.Nullable;
+import javax.validation.Valid;
+import javax.validation.constraints.Size;
+import java.math.BigDecimal;
+import java.util.List;
+
+@Value.Immutable
+@JsonSerialize
+@JsonDeserialize(as = ImmutableManagerFunds.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Value.Style(jdkOnly = true) // Required if the below entity will be used in a Map, List, Set or any other collection
+public interface ManagerFunds {
+    /**
+     * current value of the funds allocated to the manager
+     */
+    @Valid BigDecimal getCurrent();
+
+    /**
+     * list of all values of the manager funds entity in the past, including the current value
+     */
+    @Valid
+    @Nullable
+    @Readonly
+    @Size(min = 1)
+    List<BigDecimal> getHistory();
+}

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/core/utils/DashboardInternalModule.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/core/utils/DashboardInternalModule.java
@@ -23,12 +23,12 @@ import java.util.stream.Collectors;
  * A Jackson module that filter out properties annotated with @InternalField
  */
 @Provider
-public class PlayerInternalModule extends Module {
-    private static final Logger LOGGER = LoggerFactory.getLogger(PlayerInternalModule.class);
+public class DashboardInternalModule extends Module {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DashboardInternalModule.class);
 
     @Override
     public String getModuleName() {
-        return "PlayerInternalModule";
+        return "DashboardInternalModule";
     }
 
     @Override
@@ -40,17 +40,17 @@ public class PlayerInternalModule extends Module {
     @Override
     public void setupModule(SetupContext setupContext) {
         if (LOGGER.isInfoEnabled()) {
-            LOGGER.info("initializing PlayerInternalModule");
+            LOGGER.info("initializing DashboardInternalModule");
         }
 
-        setupContext.addBeanSerializerModifier(new PlayerInternalBeanSerializerModifier());
-        setupContext.addBeanDeserializerModifier(new PlayerInternalBeanDeserializerModifier());
+        setupContext.addBeanSerializerModifier(new DashboardInternalBeanSerializerModifier());
+        setupContext.addBeanDeserializerModifier(new DashboardInternalBeanDeserializerModifier());
     }
 
     /**
      * Filters out properties marked with @InternalField during Serialization
      */
-    public static class PlayerInternalBeanSerializerModifier extends BeanSerializerModifier {
+    public static class DashboardInternalBeanSerializerModifier extends BeanSerializerModifier {
 
         @Override
         public List<BeanPropertyWriter> changeProperties(SerializationConfig config, BeanDescription beanDescription,
@@ -64,7 +64,7 @@ public class PlayerInternalModule extends Module {
     /**
      * Filters out properties marked with @InternalField during Deserialization
      */
-    public static class PlayerInternalBeanDeserializerModifier extends BeanDeserializerModifier {
+    public static class DashboardInternalBeanDeserializerModifier extends BeanDeserializerModifier {
 
         @Override
         public BeanDeserializerBuilder updateBuilder(DeserializationConfig deserializationConfig,

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/core/utils/DashboardReadonlyModule.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/core/utils/DashboardReadonlyModule.java
@@ -1,0 +1,61 @@
+package com.footballstatsdashboard.core.utils;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerBuilder;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
+import com.fasterxml.jackson.databind.deser.SettableBeanProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class DashboardReadonlyModule extends Module {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DashboardReadonlyModule.class);
+
+    @Override
+    public String getModuleName() {
+        return "DashboardReadonlyModule";
+    }
+
+    @Override
+    public Version version() {
+        return new Version(1, 0, 0, "SNAPSHOT", "com.footballstatsdashboard",
+                "football-dashboard-parent");
+    }
+
+    @Override
+    public void setupModule(SetupContext setupContext) {
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("initializing DashboardReadonlyModule");
+        }
+
+        setupContext.addBeanDeserializerModifier(new DashboardReadonlyBeanDeserializerModifier());
+    }
+
+    /**
+     * Filters out properties marked with @Readonly during Deserialization
+     */
+    public static class DashboardReadonlyBeanDeserializerModifier extends BeanDeserializerModifier {
+
+        @Override
+        public BeanDeserializerBuilder updateBuilder(DeserializationConfig deserializationConfig,
+                                                     BeanDescription beanDescription, BeanDeserializerBuilder builder) {
+            Iterator<SettableBeanProperty> propertyIterator = builder.getProperties();
+            List<SettableBeanProperty> propertiesToRemove = new ArrayList<>();
+            while (propertyIterator.hasNext()) {
+                SettableBeanProperty property = propertyIterator.next();
+                if (property.getAnnotation(Readonly.class) != null) {
+                    propertiesToRemove.add(property);
+                }
+            }
+
+            propertiesToRemove.forEach(property -> builder.removeProperty(property.getFullName()));
+            return builder;
+        }
+    }
+}

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/core/utils/Readonly.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/core/utils/Readonly.java
@@ -1,0 +1,11 @@
+package com.footballstatsdashboard.core.utils;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(value = { ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Readonly {
+}

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/resources/ClubResource.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/resources/ClubResource.java
@@ -39,7 +39,6 @@ import static com.footballstatsdashboard.core.utils.Constants.CLUB_V1_BASE_PATH;
 public class ClubResource {
     private static final Logger LOGGER = LoggerFactory.getLogger(ClubResource.class);
 
-//    private final ClubDAO<ResourceKey> clubDAO;
     private final ClubService clubService;
 
     public ClubResource(ClubService clubService) {
@@ -69,9 +68,30 @@ public class ClubResource {
             LOGGER.info("createClub() request.");
         }
 
-        // TODO: 17/04/21 add more internal data when business logic becomes complicated
         if (StringUtils.isEmpty(incomingClub.getName())) {
             String errorMessage = "Empty club name is not allowed!";
+            int statusCode = HttpStatus.BAD_REQUEST_400;
+            LOGGER.error(errorMessage);
+            Map<String, Object> params = ImmutableMap.of(
+                    "status", statusCode,
+                    "message", errorMessage
+            );
+            return Response.status(statusCode).entity(params).build();
+        }
+
+        if (incomingClub.getIncome() == null) {
+            String errorMessage = "New club must have income data!";
+            int statusCode = HttpStatus.BAD_REQUEST_400;
+            LOGGER.error(errorMessage);
+            Map<String, Object> params = ImmutableMap.of(
+                    "status", statusCode,
+                    "message", errorMessage
+            );
+            return Response.status(statusCode).entity(params).build();
+        }
+
+        if (incomingClub.getExpenditure() == null) {
+            String errorMessage = "New club must have expenditure data!";
             int statusCode = HttpStatus.BAD_REQUEST_400;
             LOGGER.error(errorMessage);
             Map<String, Object> params = ImmutableMap.of(

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/resources/ClubResource.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/resources/ClubResource.java
@@ -68,6 +68,7 @@ public class ClubResource {
             LOGGER.info("createClub() request.");
         }
 
+        // TODO: 1/8/2022 move all these validations into service once validation layer is ready
         if (StringUtils.isEmpty(incomingClub.getName())) {
             String errorMessage = "Empty club name is not allowed!";
             int statusCode = HttpStatus.BAD_REQUEST_400;
@@ -79,6 +80,17 @@ public class ClubResource {
             return Response.status(statusCode).entity(params).build();
         }
 
+        if (incomingClub.getTransferBudget().add(incomingClub.getWageBudget())
+                .compareTo(incomingClub.getManagerFunds().getCurrent()) != 0) {
+            String errorMessage = "Transfer and wage budgets must add up to manager funds!";
+            int statusCode = HttpStatus.BAD_REQUEST_400;
+            LOGGER.error(errorMessage);
+            Map<String, Object> params = ImmutableMap.of(
+                    "status", statusCode,
+                    "message", errorMessage
+            );
+            return Response.status(statusCode).entity(params).build();
+        }
         if (incomingClub.getIncome() == null) {
             String errorMessage = "New club must have income data!";
             int statusCode = HttpStatus.BAD_REQUEST_400;

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/resources/ClubResource.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/resources/ClubResource.java
@@ -1,7 +1,7 @@
 package com.footballstatsdashboard.resources;
 
 import com.footballstatsdashboard.api.model.User;
-import com.footballstatsdashboard.api.model.club.Club;
+import com.footballstatsdashboard.api.model.Club;
 import com.footballstatsdashboard.api.model.club.ClubSummary;
 import com.footballstatsdashboard.api.model.club.SquadPlayer;
 import com.footballstatsdashboard.services.ClubService;

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/resources/ClubResource.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/resources/ClubResource.java
@@ -129,6 +129,18 @@ public class ClubResource {
             LOGGER.info("updateClub() request for club with ID: {}", existingClubId);
         }
 
+        if (incomingClub.getTransferBudget().add(incomingClub.getWageBudget())
+                .compareTo(incomingClub.getManagerFunds().getCurrent()) != 0) {
+            String errorMessage = "Transfer and wage budgets must add up to manager funds!";
+            int statusCode = HttpStatus.BAD_REQUEST_400;
+            LOGGER.error(errorMessage);
+            Map<String, Object> params = ImmutableMap.of(
+                    "status", statusCode,
+                    "message", errorMessage
+            );
+            return Response.status(statusCode).entity(params).build();
+        }
+
         Club existingClub = this.clubService.getClub(existingClubId);
         if (existingClub.getId().equals(incomingClub.getId())) {
             // TODO: 15/04/21 add validations by checking incoming club data against existing one

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/resources/PlayerResource.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/resources/PlayerResource.java
@@ -2,7 +2,7 @@ package com.footballstatsdashboard.resources;
 
 import com.footballstatsdashboard.api.model.Player;
 import com.footballstatsdashboard.api.model.User;
-import com.footballstatsdashboard.api.model.club.Club;
+import com.footballstatsdashboard.api.model.Club;
 import com.footballstatsdashboard.services.ClubService;
 import com.footballstatsdashboard.services.PlayerService;
 import io.dropwizard.auth.Auth;

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
@@ -61,8 +61,6 @@ public class ClubService {
         Club updatedClub = ImmutableClub.builder()
                 .from(existingClub)
                 .name(incomingClub.getName())
-                .income(incomingClub.getIncome())
-                .expenditure(incomingClub.getExpenditure())
                 .transferBudget(incomingClub.getTransferBudget())
                 .wageBudget(incomingClub.getWageBudget())
                 .lastModifiedDate(LocalDate.now())

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
@@ -1,14 +1,20 @@
 package com.footballstatsdashboard.services;
 
 import com.footballstatsdashboard.api.model.Club;
-import com.footballstatsdashboard.api.model.club.ClubSummary;
 import com.footballstatsdashboard.api.model.ImmutableClub;
+import com.footballstatsdashboard.api.model.club.ClubSummary;
+import com.footballstatsdashboard.api.model.club.Expenditure;
+import com.footballstatsdashboard.api.model.club.ImmutableExpenditure;
+import com.footballstatsdashboard.api.model.club.ImmutableIncome;
+import com.footballstatsdashboard.api.model.club.Income;
 import com.footballstatsdashboard.api.model.club.SquadPlayer;
 import com.footballstatsdashboard.db.ClubDAO;
 import com.footballstatsdashboard.db.key.ResourceKey;
 
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 public class ClubService {
@@ -24,10 +30,22 @@ public class ClubService {
     }
 
     public Club createClub(Club incomingClub, UUID userId, String createdBy) {
+        Income newClubIncome = ImmutableIncome.builder()
+                .from(Objects.requireNonNull(incomingClub.getIncome()))
+                .history(Collections.singletonList(incomingClub.getIncome().getCurrent()))
+                .build();
+
+        Expenditure newClubExpenditure = ImmutableExpenditure.builder()
+                .from(Objects.requireNonNull(incomingClub.getExpenditure()))
+                .history(Collections.singletonList(incomingClub.getExpenditure().getCurrent()))
+                .build();
+
         LocalDate currentDate = LocalDate.now();
         Club newClub = ImmutableClub.builder()
                 .from(incomingClub)
                 .userId(userId)
+                .income(newClubIncome)
+                .expenditure(newClubExpenditure)
                 .createdDate(currentDate)
                 .lastModifiedDate(currentDate)
                 .createdBy(createdBy)

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
@@ -1,8 +1,8 @@
 package com.footballstatsdashboard.services;
 
-import com.footballstatsdashboard.api.model.club.Club;
+import com.footballstatsdashboard.api.model.Club;
 import com.footballstatsdashboard.api.model.club.ClubSummary;
-import com.footballstatsdashboard.api.model.club.ImmutableClub;
+import com.footballstatsdashboard.api.model.ImmutableClub;
 import com.footballstatsdashboard.api.model.club.SquadPlayer;
 import com.footballstatsdashboard.db.ClubDAO;
 import com.footballstatsdashboard.db.key.ResourceKey;

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
@@ -6,7 +6,9 @@ import com.footballstatsdashboard.api.model.club.ClubSummary;
 import com.footballstatsdashboard.api.model.club.Expenditure;
 import com.footballstatsdashboard.api.model.club.ImmutableExpenditure;
 import com.footballstatsdashboard.api.model.club.ImmutableIncome;
+import com.footballstatsdashboard.api.model.club.ImmutableManagerFunds;
 import com.footballstatsdashboard.api.model.club.Income;
+import com.footballstatsdashboard.api.model.club.ManagerFunds;
 import com.footballstatsdashboard.api.model.club.SquadPlayer;
 import com.footballstatsdashboard.db.ClubDAO;
 import com.footballstatsdashboard.db.key.ResourceKey;
@@ -30,6 +32,11 @@ public class ClubService {
     }
 
     public Club createClub(Club incomingClub, UUID userId, String createdBy) {
+        ManagerFunds newManagerFunds = ImmutableManagerFunds.builder()
+                .from(incomingClub.getManagerFunds())
+                .history(Collections.singletonList(incomingClub.getManagerFunds().getCurrent()))
+                .build();
+
         Income newClubIncome = ImmutableIncome.builder()
                 .from(Objects.requireNonNull(incomingClub.getIncome()))
                 .history(Collections.singletonList(incomingClub.getIncome().getCurrent()))
@@ -44,6 +51,7 @@ public class ClubService {
         Club newClub = ImmutableClub.builder()
                 .from(incomingClub)
                 .userId(userId)
+                .managerFunds(newManagerFunds)
                 .income(newClubIncome)
                 .expenditure(newClubExpenditure)
                 .createdDate(currentDate)

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/PlayerService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/PlayerService.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.footballstatsdashboard.api.model.CountryCodeMetadata;
 import com.footballstatsdashboard.api.model.ImmutablePlayer;
 import com.footballstatsdashboard.api.model.Player;
-import com.footballstatsdashboard.api.model.club.Club;
+import com.footballstatsdashboard.api.model.Club;
 import com.footballstatsdashboard.api.model.player.Ability;
 import com.footballstatsdashboard.api.model.player.Attribute;
 import com.footballstatsdashboard.api.model.player.ImmutableAbility;

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/ClubDataProvider.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/ClubDataProvider.java
@@ -122,8 +122,10 @@ public final class ClubDataProvider {
             }
 
             // add the required fields which don't require dynamic values in test suites and build the club entity
+            BigDecimal defaultTotalFunds = DEFAULT_TRANSFER_BUDGET.add(DEFAULT_WAGE_BUDGET);
             ManagerFunds defaultManagerFunds = ImmutableManagerFunds.builder()
-                    .current(DEFAULT_TRANSFER_BUDGET.add(DEFAULT_WAGE_BUDGET))
+                    .current(defaultTotalFunds)
+                    .history(isExistingClub ? ImmutableList.of(defaultTotalFunds) : ImmutableList.of())
                     .build();
             return this.baseClub
                     .name(this.customClubName != null ? this.customClubName : DEFAULT_CLUB_NAME)
@@ -160,8 +162,23 @@ public final class ClubDataProvider {
             return this;
         }
 
+        public ModifiedClubBuilder withUpdatedTransferBudget(BigDecimal newTransferBudget) {
+            baseClub.transferBudget(newTransferBudget);
+            return this;
+        }
+
         public ModifiedClubBuilder withUpdatedWageBudget(BigDecimal newWageBudget) {
             baseClub.wageBudget(newWageBudget);
+            return this;
+        }
+
+        public ModifiedClubBuilder withUpdatedManagerFunds(BigDecimal newManagerFunds) {
+            ManagerFunds updatedManagerFunds = ImmutableManagerFunds.builder()
+                    .from(clubReference.getManagerFunds())
+                    .current(newManagerFunds)
+                    .addHistory(newManagerFunds)
+                    .build();
+            baseClub.managerFunds(updatedManagerFunds);
             return this;
         }
 

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/ClubDataProvider.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/ClubDataProvider.java
@@ -1,8 +1,8 @@
 package com.footballstatsdashboard;
 
-import com.footballstatsdashboard.api.model.club.Club;
+import com.footballstatsdashboard.api.model.Club;
 import com.footballstatsdashboard.api.model.club.ClubSummary;
-import com.footballstatsdashboard.api.model.club.ImmutableClub;
+import com.footballstatsdashboard.api.model.ImmutableClub;
 import com.footballstatsdashboard.api.model.club.ImmutableClubSummary;
 
 import java.math.BigDecimal;

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/ClubDataProvider.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/ClubDataProvider.java
@@ -7,7 +7,9 @@ import com.footballstatsdashboard.api.model.club.Expenditure;
 import com.footballstatsdashboard.api.model.club.ImmutableClubSummary;
 import com.footballstatsdashboard.api.model.club.ImmutableExpenditure;
 import com.footballstatsdashboard.api.model.club.ImmutableIncome;
+import com.footballstatsdashboard.api.model.club.ImmutableManagerFunds;
 import com.footballstatsdashboard.api.model.club.Income;
+import com.footballstatsdashboard.api.model.club.ManagerFunds;
 import com.google.common.collect.ImmutableList;
 
 import java.math.BigDecimal;
@@ -22,11 +24,13 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public final class ClubDataProvider {
-    public static final BigDecimal CURRENT_INCOME = new BigDecimal("1000");
-    public static final BigDecimal CURRENT_EXPENDITURE = new BigDecimal("2000");
     private static final String CREATED_BY = "fake email";
-    private static final String DEFAULT_CLUB_NAME = "fake club name";
     private static final int NUMBER_OF_CLUBS = 3;
+    private static final BigDecimal CURRENT_INCOME = new BigDecimal("1000");
+    private static final BigDecimal CURRENT_EXPENDITURE = new BigDecimal("2000");
+    private static final String DEFAULT_CLUB_NAME = "fake club name";
+    private static final BigDecimal DEFAULT_TRANSFER_BUDGET = new BigDecimal("500");
+    private static final BigDecimal DEFAULT_WAGE_BUDGET = new BigDecimal("200");
 
     private ClubDataProvider() { }
 
@@ -37,6 +41,10 @@ public final class ClubDataProvider {
         private boolean isExistingClub = false;
         private String customClubName = null;
         private UUID existingUserId = null;
+        private BigDecimal customTransferBudget;
+        private BigDecimal customWageBudget;
+        private ManagerFunds customManagerFunds;
+
         private final ImmutableClub.Builder baseClub = ImmutableClub.builder();
 
         private ClubBuilder() { }
@@ -83,6 +91,23 @@ public final class ClubDataProvider {
             return this;
         }
 
+        public ClubBuilder customTransferBudget(BigDecimal transferBudget) {
+            this.customTransferBudget = transferBudget;
+            return this;
+        }
+
+        public ClubBuilder customWageBudget(BigDecimal wageBudget) {
+            this.customWageBudget = wageBudget;
+            return this;
+        }
+
+        public ClubBuilder customManagerFunds(BigDecimal managerFunds) {
+            this.customManagerFunds = ImmutableManagerFunds.builder()
+                    .current(managerFunds)
+                    .build();
+            return this;
+        }
+
         public Club build() {
             // add some house-keeping fields if it is an existing club
             if (isExistingClub) {
@@ -97,10 +122,15 @@ public final class ClubDataProvider {
             }
 
             // add the required fields which don't require dynamic values in test suites and build the club entity
+            ManagerFunds defaultManagerFunds = ImmutableManagerFunds.builder()
+                    .current(DEFAULT_TRANSFER_BUDGET.add(DEFAULT_WAGE_BUDGET))
+                    .build();
             return this.baseClub
                     .name(this.customClubName != null ? this.customClubName : DEFAULT_CLUB_NAME)
-                    .transferBudget(new BigDecimal("500"))
-                    .wageBudget(new BigDecimal("200"))
+                    .managerFunds(this.customManagerFunds != null ? this.customManagerFunds : defaultManagerFunds)
+                    .transferBudget(this.customTransferBudget != null ?
+                            this.customTransferBudget : DEFAULT_TRANSFER_BUDGET)
+                    .wageBudget(this.customWageBudget != null ? this.customWageBudget : DEFAULT_WAGE_BUDGET)
                     .build();
         }
     }

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/ClubDataProvider.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/ClubDataProvider.java
@@ -175,6 +175,9 @@ public final class ClubDataProvider {
                     .isExisting(true)
                     .existingUserId(userId)
                     .customClubName(DEFAULT_CLUB_NAME + i)
+                    .withId(UUID.randomUUID())
+                    .withIncome()
+                    .withExpenditure()
                     .build();
             return ImmutableClubSummary.builder()
                     .clubId(existingClub.getId())

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/ClubDataProvider.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/ClubDataProvider.java
@@ -3,7 +3,12 @@ package com.footballstatsdashboard;
 import com.footballstatsdashboard.api.model.Club;
 import com.footballstatsdashboard.api.model.club.ClubSummary;
 import com.footballstatsdashboard.api.model.ImmutableClub;
+import com.footballstatsdashboard.api.model.club.Expenditure;
 import com.footballstatsdashboard.api.model.club.ImmutableClubSummary;
+import com.footballstatsdashboard.api.model.club.ImmutableExpenditure;
+import com.footballstatsdashboard.api.model.club.ImmutableIncome;
+import com.footballstatsdashboard.api.model.club.Income;
+import com.google.common.collect.ImmutableList;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -48,6 +53,26 @@ public final class ClubDataProvider {
             return this;
         }
 
+        public ClubBuilder withIncome() {
+            BigDecimal currentIncome = new BigDecimal("1000");
+            Income clubIncome = ImmutableIncome.builder()
+                    .current(currentIncome)
+                    .history(isExistingClub ? ImmutableList.of(currentIncome) : ImmutableList.of())
+                    .build();
+            baseClub.income(clubIncome);
+            return this;
+        }
+
+        public ClubBuilder withExpenditure() {
+            BigDecimal currentExpenditure = new BigDecimal("2000");
+            Expenditure clubExpenditure = ImmutableExpenditure.builder()
+                    .current(currentExpenditure)
+                    .history(isExistingClub ? ImmutableList.of(currentExpenditure) : ImmutableList.of())
+                    .build();
+            baseClub.expenditure(clubExpenditure);
+            return this;
+        }
+
         public ClubBuilder customClubName(String clubName) {
             this.customClubName = clubName;
             return this;
@@ -74,8 +99,6 @@ public final class ClubDataProvider {
             // add the required fields which don't require dynamic values in test suites and build the club entity
             return this.baseClub
                     .name(this.customClubName != null ? this.customClubName : DEFAULT_CLUB_NAME)
-                    .expenditure(new BigDecimal("1000"))
-                    .income(new BigDecimal("2000"))
                     .transferBudget(new BigDecimal("500"))
                     .wageBudget(new BigDecimal("200"))
                     .build();

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/ClubDataProvider.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/ClubDataProvider.java
@@ -22,6 +22,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public final class ClubDataProvider {
+    public static final BigDecimal CURRENT_INCOME = new BigDecimal("1000");
+    public static final BigDecimal CURRENT_EXPENDITURE = new BigDecimal("2000");
     private static final String CREATED_BY = "fake email";
     private static final String DEFAULT_CLUB_NAME = "fake club name";
     private static final int NUMBER_OF_CLUBS = 3;
@@ -54,20 +56,18 @@ public final class ClubDataProvider {
         }
 
         public ClubBuilder withIncome() {
-            BigDecimal currentIncome = new BigDecimal("1000");
             Income clubIncome = ImmutableIncome.builder()
-                    .current(currentIncome)
-                    .history(isExistingClub ? ImmutableList.of(currentIncome) : ImmutableList.of())
+                    .current(CURRENT_INCOME)
+                    .history(isExistingClub ? ImmutableList.of(CURRENT_INCOME) : ImmutableList.of())
                     .build();
             baseClub.income(clubIncome);
             return this;
         }
 
         public ClubBuilder withExpenditure() {
-            BigDecimal currentExpenditure = new BigDecimal("2000");
             Expenditure clubExpenditure = ImmutableExpenditure.builder()
-                    .current(currentExpenditure)
-                    .history(isExistingClub ? ImmutableList.of(currentExpenditure) : ImmutableList.of())
+                    .current(CURRENT_EXPENDITURE)
+                    .history(isExistingClub ? ImmutableList.of(CURRENT_EXPENDITURE) : ImmutableList.of())
                     .build();
             baseClub.expenditure(clubExpenditure);
             return this;
@@ -111,6 +111,7 @@ public final class ClubDataProvider {
      */
     public static final class ModifiedClubBuilder {
         private ImmutableClub.Builder baseClub = ImmutableClub.builder();
+        private Club clubReference;
 
         private ModifiedClubBuilder() { }
 
@@ -119,12 +120,40 @@ public final class ClubDataProvider {
         }
 
         public ModifiedClubBuilder from(Club club) {
+            clubReference = club;
             baseClub = ImmutableClub.builder().from(club);
+            return this;
+        }
+
+        public ModifiedClubBuilder withUpdatedName(String newName) {
+            baseClub.name(newName);
             return this;
         }
 
         public ModifiedClubBuilder withUpdatedWageBudget(BigDecimal newWageBudget) {
             baseClub.wageBudget(newWageBudget);
+            return this;
+        }
+
+        public ModifiedClubBuilder withUpdatedIncome() {
+            BigDecimal updatedIncomeValue = CURRENT_INCOME.add(new BigDecimal("1000"));
+            Income updatedIncome = ImmutableIncome.builder()
+                    .from(Objects.requireNonNull(clubReference.getIncome()))
+                    .current(updatedIncomeValue)
+                    .addHistory(updatedIncomeValue)
+                    .build();
+            baseClub.income(updatedIncome);
+            return this;
+        }
+
+        public ModifiedClubBuilder withUpdatedExpenditure() {
+            BigDecimal updatedExpenditureValue = CURRENT_EXPENDITURE.add(new BigDecimal("1000"));
+            Expenditure updatedExpenditure = ImmutableExpenditure.builder()
+                    .from(Objects.requireNonNull(clubReference.getExpenditure()))
+                    .current(updatedExpenditureValue)
+                    .addHistory(updatedExpenditureValue)
+                    .build();
+            baseClub.expenditure(updatedExpenditure);
             return this;
         }
 

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/ClubResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/ClubResourceTest.java
@@ -166,6 +166,53 @@ public class ClubResourceTest {
     }
 
     /**
+     * given that the request contains a club entity whose transfer and wage budgets is greater than the manager funds
+     * set, tests that no data is persisted and a 400 Bad Request response status is returned
+     */
+    @Test
+    public void createClubWithIncorrectBudget() {
+        // setup
+        Club incomingClubWithIncorrectBudget = ClubDataProvider.ClubBuilder.builder()
+                .isExisting(false)
+                .customTransferBudget(new BigDecimal("5000"))
+                .customWageBudget(new BigDecimal("2000"))
+                .withIncome()
+                .withExpenditure()
+                .build();
+
+        // execute
+        Response clubResponse = clubResource.createClub(userPrincipal, incomingClubWithIncorrectBudget, uriInfo);
+
+        // assert
+        verify(clubService, never()).createClub(any(), any(), anyString());
+        assertNotNull(clubResponse);
+        assertEquals(HttpStatus.BAD_REQUEST_400, clubResponse.getStatus());
+    }
+
+    /**
+     * given that the request contains a club entity whose manager funds is greater than the transfer and wage budgets
+     * set, tests that no data is persisted and a 400 Bad Request response status is returned
+     */
+    @Test
+    public void createClubWithIncorrectManagerFunds() {
+        // setup
+        Club incomingClubWithIncorrectBudget = ClubDataProvider.ClubBuilder.builder()
+                .isExisting(false)
+                .customManagerFunds(new BigDecimal("10000"))
+                .withIncome()
+                .withExpenditure()
+                .build();
+
+        // execute
+        Response clubResponse = clubResource.createClub(userPrincipal, incomingClubWithIncorrectBudget, uriInfo);
+
+        // assert
+        verify(clubService, never()).createClub(any(), any(), anyString());
+        assertNotNull(clubResponse);
+        assertEquals(HttpStatus.BAD_REQUEST_400, clubResponse.getStatus());
+    }
+
+    /**
      * given that the request contains a club entity without valid income data, tests that no data is persisted and a
      * 400 Bad Request response status is returned
      */

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/ClubResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/ClubResourceTest.java
@@ -88,6 +88,8 @@ public class ClubResourceTest {
                 .isExisting(true)
                 .existingUserId(userPrincipal.getId())
                 .withId(clubId)
+                .withIncome()
+                .withExpenditure()
                 .build();
         when(clubService.getClub(eq(clubId))).thenReturn(existingClub);
 
@@ -115,11 +117,15 @@ public class ClubResourceTest {
         // setup
         Club incomingClub = ClubDataProvider.ClubBuilder.builder()
                 .isExisting(false)
+                .withIncome()
+                .withExpenditure()
                 .build();
         Club createdClub = ClubDataProvider.ClubBuilder.builder()
                 .isExisting(true)
                 .existingUserId(userPrincipal.getId())
                 .withId(incomingClub.getId())
+                .withIncome()
+                .withExpenditure()
                 .build();
         when(clubService.createClub(any(), any(), anyString())).thenReturn(createdClub);
 
@@ -146,10 +152,54 @@ public class ClubResourceTest {
         Club incomingClubWithNoName = ClubDataProvider.ClubBuilder.builder()
                 .isExisting(false)
                 .customClubName("")
+                .withIncome()
+                .withExpenditure()
                 .build();
 
         // execute
         Response clubResponse = clubResource.createClub(userPrincipal, incomingClubWithNoName, uriInfo);
+
+        // assert
+        verify(clubService, never()).createClub(any(), any(), anyString());
+        assertNotNull(clubResponse);
+        assertEquals(HttpStatus.BAD_REQUEST_400, clubResponse.getStatus());
+    }
+
+    /**
+     * given that the request contains a club entity without valid income data, tests that no data is persisted and a
+     * 400 Bad Request response status is returned
+     */
+    @Test
+    public void createClubWithoutIncomeData() {
+        // setup
+        Club incomingClubWithNoIncomeData = ClubDataProvider.ClubBuilder.builder()
+                .isExisting(false)
+                .withExpenditure()
+                .build();
+
+        // execute
+        Response clubResponse = clubResource.createClub(userPrincipal, incomingClubWithNoIncomeData, uriInfo);
+
+        // assert
+        verify(clubService, never()).createClub(any(), any(), anyString());
+        assertNotNull(clubResponse);
+        assertEquals(HttpStatus.BAD_REQUEST_400, clubResponse.getStatus());
+    }
+
+    /**
+     * given that the request contains a club entity without valid income data, tests that no data is persisted and a
+     * 400 Bad Request response status is returned
+     */
+    @Test
+    public void createClubWithoutExpenditureData() {
+        // setup
+        Club incomingClubWithNoExpenditureData = ClubDataProvider.ClubBuilder.builder()
+                .isExisting(false)
+                .withIncome()
+                .build();
+
+        // execute
+        Response clubResponse = clubResource.createClub(userPrincipal, incomingClubWithNoExpenditureData, uriInfo);
 
         // assert
         verify(clubService, never()).createClub(any(), any(), anyString());

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/ClubResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/ClubResourceTest.java
@@ -218,6 +218,8 @@ public class ClubResourceTest {
                 .isExisting(true)
                 .existingUserId(userPrincipal.getId())
                 .withId(existingClubId)
+                .withIncome()
+                .withExpenditure()
                 .build();
         when(clubService.getClub(any())).thenReturn(existingClub);
 
@@ -268,6 +270,8 @@ public class ClubResourceTest {
                 .isExisting(true)
                 .existingUserId(userPrincipal.getId())
                 .withId(existingClubId)
+                .withIncome()
+                .withExpenditure()
                 .build();
         when(clubService.getClub(any())).thenReturn(existingClub);
 

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/ClubResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/ClubResourceTest.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.footballstatsdashboard.ClubDataProvider;
 import com.footballstatsdashboard.api.model.ImmutableUser;
 import com.footballstatsdashboard.api.model.User;
-import com.footballstatsdashboard.api.model.club.Club;
+import com.footballstatsdashboard.api.model.Club;
 import com.footballstatsdashboard.api.model.club.ClubSummary;
 import com.footballstatsdashboard.api.model.club.ImmutableSquadPlayer;
 import com.footballstatsdashboard.api.model.club.SquadPlayer;

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/PlayerResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/PlayerResourceTest.java
@@ -6,7 +6,7 @@ import com.footballstatsdashboard.PlayerDataProvider;
 import com.footballstatsdashboard.api.model.ImmutableUser;
 import com.footballstatsdashboard.api.model.Player;
 import com.footballstatsdashboard.api.model.User;
-import com.footballstatsdashboard.api.model.club.Club;
+import com.footballstatsdashboard.api.model.Club;
 import com.footballstatsdashboard.services.ClubService;
 import com.footballstatsdashboard.services.PlayerService;
 import io.dropwizard.jackson.Jackson;

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/services/ClubServiceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/services/ClubServiceTest.java
@@ -1,7 +1,7 @@
 package com.footballstatsdashboard.services;
 
 import com.footballstatsdashboard.ClubDataProvider;
-import com.footballstatsdashboard.api.model.club.Club;
+import com.footballstatsdashboard.api.model.Club;
 import com.footballstatsdashboard.api.model.club.ClubSummary;
 import com.footballstatsdashboard.api.model.club.ImmutableSquadPlayer;
 import com.footballstatsdashboard.api.model.club.SquadPlayer;

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/services/ClubServiceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/services/ClubServiceTest.java
@@ -62,6 +62,8 @@ public class ClubServiceTest {
                 .isExisting(true)
                 .existingUserId(userId)
                 .withId(clubId)
+                .withIncome()
+                .withExpenditure()
                 .build();
         when(clubDAO.getDocument(any(), any())).thenReturn(clubFromCouchbase);
 
@@ -103,6 +105,8 @@ public class ClubServiceTest {
         // setup
         Club incomingClub = ClubDataProvider.ClubBuilder.builder()
                 .isExisting(false)
+                .withIncome()
+                .withExpenditure()
                 .build();
         ArgumentCaptor<Club> newClubCaptor = ArgumentCaptor.forClass(Club.class);
 
@@ -115,6 +119,15 @@ public class ClubServiceTest {
         assertEquals(createdClub, newClub);
 
         assertEquals(incomingClub.getId(), createdClub.getId());
+
+        // verify income and expenditure histories are initialized during creation
+        assertNotNull(createdClub.getIncome());
+        assertNotNull(createdClub.getIncome().getHistory());
+        assertEquals(1, createdClub.getIncome().getHistory().size());
+
+        assertNotNull(createdClub.getExpenditure());
+        assertNotNull(createdClub.getExpenditure().getHistory());
+        assertEquals(1, createdClub.getExpenditure().getHistory().size());
 
         // assertions for general house-keeping fields
         assertNotNull(createdClub.getCreatedDate());

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/services/ClubServiceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/services/ClubServiceTest.java
@@ -122,7 +122,10 @@ public class ClubServiceTest {
 
         assertEquals(incomingClub.getId(), createdClub.getId());
 
-        // verify income and expenditure histories are initialized during creation
+        // verify manager funds, income and expenditure histories are initialized during creation
+        assertNotNull(createdClub.getManagerFunds().getHistory());
+        assertEquals(1, createdClub.getManagerFunds().getHistory().size());
+
         assertNotNull(createdClub.getIncome());
         assertNotNull(createdClub.getIncome().getHistory());
         assertEquals(1, createdClub.getIncome().getHistory().size());

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/services/PlayerServiceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/services/PlayerServiceTest.java
@@ -5,7 +5,7 @@ import com.footballstatsdashboard.ClubDataProvider;
 import com.footballstatsdashboard.PlayerDataProvider;
 import com.footballstatsdashboard.api.model.CountryCodeMetadata;
 import com.footballstatsdashboard.api.model.Player;
-import com.footballstatsdashboard.api.model.club.Club;
+import com.footballstatsdashboard.api.model.Club;
 import com.footballstatsdashboard.api.model.player.Attribute;
 import com.footballstatsdashboard.api.model.player.Metadata;
 import com.footballstatsdashboard.core.utils.FixtureLoader;


### PR DESCRIPTION
## Motivation and Context
In this PR, updated the Club entity to include a new _Manager Funds_ entity (with history tracking) from which the transfer and wage budget is derived on the client. Enhanced existing functionality to allow tracking the historical values for _Income_ and _Expenditure_ properties on the _Club_ entity. Additionally, added a _Readonly_ annotation to mark certain Jackson properties as read-only when serializing and deserializing.
This PR resolves #104.

## How Has This Been Tested?
In this PR, the following scenarios have been covered with the help of unit tests -
* Income and expenditure data's history is initialized during club creation.
* Manager funds (with history) are correctly persisted during club creation.
* Club creation is aborted if income or expenditure is not present in the request.
* Club creation is also aborted if the total budget (transfer + wage) does not add up to the manager funds value present in the request.
* Income and expenditure data is not updated when updating a club entity.
* Manager funds data is not updated when only the transfer and wage budget split has changed.
* Any request to update the club entity is aborted if the total budget (transfer + wage) does not match the manager funds present in the request.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
