### PR TITLE
Bugfix: NPE when creating a new club

### DIFF
--- a/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/club/Expenditure.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/club/Expenditure.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.footballstatsdashboard.core.utils.Readonly;
 import org.immutables.value.Value;
 
+import javax.annotation.Nullable;
 import javax.validation.Valid;
 import javax.validation.constraints.Size;
 import java.math.BigDecimal;
@@ -27,6 +28,7 @@ public interface Expenditure {
      */
     @Valid
     @Readonly
+    @Nullable
     @Size(min = 1)
     List<BigDecimal> getHistory();
 }

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/ClubDataProvider.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/ClubDataProvider.java
@@ -66,7 +66,7 @@ public final class ClubDataProvider {
         public ClubBuilder withIncome() {
             Income clubIncome = ImmutableIncome.builder()
                     .current(CURRENT_INCOME)
-                    .history(isExistingClub ? ImmutableList.of(CURRENT_INCOME) : ImmutableList.of())
+                    .history(isExistingClub ? ImmutableList.of(CURRENT_INCOME) : null)
                     .build();
             baseClub.income(clubIncome);
             return this;
@@ -75,7 +75,7 @@ public final class ClubDataProvider {
         public ClubBuilder withExpenditure() {
             Expenditure clubExpenditure = ImmutableExpenditure.builder()
                     .current(CURRENT_EXPENDITURE)
-                    .history(isExistingClub ? ImmutableList.of(CURRENT_EXPENDITURE) : ImmutableList.of())
+                    .history(isExistingClub ? ImmutableList.of(CURRENT_EXPENDITURE) : null)
                     .build();
             baseClub.expenditure(clubExpenditure);
             return this;
@@ -125,7 +125,7 @@ public final class ClubDataProvider {
             BigDecimal defaultTotalFunds = DEFAULT_TRANSFER_BUDGET.add(DEFAULT_WAGE_BUDGET);
             ManagerFunds defaultManagerFunds = ImmutableManagerFunds.builder()
                     .current(defaultTotalFunds)
-                    .history(isExistingClub ? ImmutableList.of(defaultTotalFunds) : ImmutableList.of())
+                    .history(isExistingClub ? ImmutableList.of(defaultTotalFunds) : null)
                     .build();
             return this.baseClub
                     .name(this.customClubName != null ? this.customClubName : DEFAULT_CLUB_NAME)

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/PlayerDataProvider.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/PlayerDataProvider.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+// TODO: 1/9/2022 set `history` properties to null when isExisting is false
 public class PlayerDataProvider {
     private static final int PLAYER_AGE = 27;
     private static final int CURRENT_PLAYER_ABILITY = 19;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
When creating a new club, the _history_ property on a number of sub-entities like _Income_, _Expenditure_, and _ManagerFunds_ is expected to be null. However, unlike _Income_ and _Expenditure_,  the _history_ property on _ManagerFunds_ was not annotated with `@Nullable` and so was throwing a _Null Pointer Exception_. This PR addresses that problem.

## How Has This Been Tested?
The tests around this scenario were already in place but the data provider was not stubbing the data correctly. Updated the club data provider to pass in `null` for the _history_ properties on the aforementioned sub-entities.

## Types of changes
<!--- What types of changes does the code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
