### PR TITLE
Bugfix: 500 Server Error response is returned when trying to fetch all clubs belonging to a user

### DIFF
--- a/dashboard-server/src/main/java/com/footballstatsdashboard/db/ClubDAO.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/db/ClubDAO.java
@@ -27,7 +27,8 @@ public class ClubDAO<K> extends CouchbaseDAO<K> {
     }
 
     public List<ClubSummary> getClubSummariesByUserId(UUID userId) {
-        String query = String.format("Select club.* from `%s` club where club.type = 'Club' and club.userId = $userId",
+        String query = String.format("Select club.id as clubId, club.name, club.createdDate from `%s` club" +
+                        " where club.type = 'Club' and club.userId = $userId",
                 this.getBucketNameResolver().get());
         QueryOptions queryOptions = QueryOptions.queryOptions().parameters(
                 JsonObject.create().put("userId", userId.toString())


### PR DESCRIPTION
## Motivation and Context
ClubSummary entity only expects _clubId_, _name_ and _createdDate_ properties from the _Club_ document in couchbase. However, the N1QL query is returning all the fields from said document and so a 500 Server Error response is returned because it isn't possible to convert the club data into the data expected by _ClubSummary_.
In this PR, the query has been updated to only fetch the properties required by _ClubSummary_ from the _Club_ document in couchbase.

## How Has This Been Tested?
There is no existing framework to test the DAO layer. Therefore no tests have been added for this change yet.

## Types of changes
<!--- What types of changes does the code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
