### PR TITLE
Update Add Club form to match data expected by add club endpoint in server

### DIFF
--- a/dashboard-ui/src/components/CustomSlider.js
+++ b/dashboard-ui/src/components/CustomSlider.js
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import Slider from '@material-ui/core/Slider';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
+import { capitalizeLabel, formatNumberWithCommas } from '../utils';
+import { makeStyles } from '@material-ui/core/styles';
+
+const getSplitComponents = (total, percentage) => (
+    [
+        Math.trunc(total * percentage / 100),
+        Math.trunc(total * (1 - percentage / 100))
+    ]
+);
+
+const useStyles = makeStyles(theme => ({
+    container: {
+        padding: theme.spacing(1),
+        borderStyle: 'dashed',
+        borderWidth: '1px',
+        borderRadius: '5px',
+        borderColor: theme.palette.divider,
+        backgroundColor: theme.palette.background.paper
+    }
+}));
+const INITIAL_PERCENTAGE = 100;
+export default function CustomSlider({ sliderTitle, splitMetadata: { valueToSplit, entitiesToSplit } }) {
+    const [sliderData, setSliderData] = useState({
+        currentPercentage: INITIAL_PERCENTAGE,
+        components: getSplitComponents(valueToSplit, INITIAL_PERCENTAGE)
+    });
+    const classes = useStyles();
+
+    const handleChangeFn = (_, newValue) => {
+        const updatedComponents = getSplitComponents(valueToSplit, newValue);
+        setSliderData({
+            currentPercentage: newValue,
+            components: updatedComponents
+        });
+        updatedComponents.forEach((component, idx) => {
+            entitiesToSplit[idx].handleChange({ target: { name: entitiesToSplit[idx].name, value: component }});
+        });
+    };
+
+    // update the slider data when the valueToSplit prop changes
+    useEffect(() => {
+        setSliderData({
+            ...sliderData,
+            components: getSplitComponents(valueToSplit, sliderData.currentPercentage)
+        });
+    }, [valueToSplit]);
+
+    return (
+        <div className={classes.container}>
+            <Typography variant='h6' align='center'>{sliderTitle}</Typography>
+            <Grid container spacing={2}>
+                <Grid item>
+                    <Grid container item direction='column' alignItems='flex-end' spacing={1}>
+                        <Grid item>
+                            <Typography>${formatNumberWithCommas(sliderData.components[0])}</Typography>
+                        </Grid>
+                        <Grid item>
+                            <Typography>
+                                {capitalizeLabel(entitiesToSplit[0].name, 'camelcase')}
+                            </Typography>
+                        </Grid>
+                    </Grid>
+                </Grid>
+                <Grid item xs>
+                    <Slider value={sliderData.currentPercentage} onChange={handleChangeFn} valueLabelDisplay='on' />
+                </Grid>
+                <Grid item>
+                    <Grid container item direction='column' spacing={1}>
+                        <Grid item>
+                            <Typography>
+                                ${formatNumberWithCommas(sliderData.components[1])}
+                            </Typography>
+                        </Grid>
+                        <Grid item>
+                            <Typography>
+                                {capitalizeLabel(entitiesToSplit[1].name, 'camelcase')}
+                            </Typography>
+                        </Grid>
+                    </Grid>
+                </Grid>
+            </Grid>
+        </div>
+    );
+}
+
+CustomSlider.propTypes = {
+    sliderTitle: PropTypes.string,
+    splitMetadata: PropTypes.shape({
+        valueToSplit: PropTypes.number,
+        entitiesToSplit: PropTypes.arrayOf(PropTypes.shape({
+            name: PropTypes.string,
+            handleChange: PropTypes.func
+        }))
+    })
+};

--- a/dashboard-ui/src/components/CustomSlider.js
+++ b/dashboard-ui/src/components/CustomSlider.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import Slider from '@material-ui/core/Slider';
@@ -26,11 +26,12 @@ const useStyles = makeStyles(theme => ({
 }));
 const INITIAL_PERCENTAGE = 100;
 export default function CustomSlider({ sliderTitle, splitMetadata: { valueToSplit, entitiesToSplit } }) {
+    const classes = useStyles();
+    const isFirstUpdate = useRef(true);
     const [sliderData, setSliderData] = useState({
         currentPercentage: INITIAL_PERCENTAGE,
         components: getSplitComponents(valueToSplit, INITIAL_PERCENTAGE)
     });
-    const classes = useStyles();
 
     const handleChangeFn = (_, newValue) => {
         const updatedComponents = getSplitComponents(valueToSplit, newValue);
@@ -45,9 +46,18 @@ export default function CustomSlider({ sliderTitle, splitMetadata: { valueToSpli
 
     // update the slider data when the valueToSplit prop changes
     useEffect(() => {
+        // skip updating state and invoking change handlers if this is being called on mount, i.e. not on user input
+        if (isFirstUpdate.current) {
+            isFirstUpdate.current = false;
+            return;
+        }
+        const splitComponents = getSplitComponents(valueToSplit, sliderData.currentPercentage);
         setSliderData({
             ...sliderData,
-            components: getSplitComponents(valueToSplit, sliderData.currentPercentage)
+            components: splitComponents
+        });
+        splitComponents.forEach((component, idx) => {
+            entitiesToSplit[idx].handleChange({ target: { name: entitiesToSplit[idx].name, value: component }});
         });
     }, [valueToSplit]);
 

--- a/dashboard-ui/src/components/CustomSlider.js
+++ b/dashboard-ui/src/components/CustomSlider.js
@@ -10,7 +10,7 @@ import { makeStyles } from '@material-ui/core/styles';
 const getSplitComponents = (total, percentage) => (
     [
         Math.trunc(total * percentage / 100),
-        Math.trunc(total * (1 - percentage / 100))
+        Math.ceil(total * (1 - percentage / 100))
     ]
 );
 

--- a/dashboard-ui/src/components/CustomSlider.test.js
+++ b/dashboard-ui/src/components/CustomSlider.test.js
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import CustomSlider from './CustomSlider';
+
+const defaultProps = {
+    sliderTitle: 'fake slider title',
+    splitMetadata: {
+        valueToSplit: 1000,
+        entitiesToSplit: [{
+            name: 'entityA',
+            handleChange: jest.fn()
+        }, {
+            name: 'entityB',
+            handleChange: jest.fn()
+        }]
+    }
+};
+
+beforeEach(() => {
+    jest.resetAllMocks();
+});
+
+it('renders successfully', () => {
+    render(<CustomSlider {...defaultProps}/>);
+    const slider = screen.getByRole('slider');
+    expect(slider).toHaveAttribute('aria-valuenow', '100');
+
+    // verify the change handlers for the components is not invoked on mount
+    const { splitMetadata: { entitiesToSplit } } = defaultProps;
+    entitiesToSplit.forEach(entity => expect(entity.handleChange).not.toHaveBeenCalled());
+});
+
+it('updating the slider calls the change handlers for each component', () => {
+    render(<CustomSlider {...defaultProps} />);
+    const slider = screen.getByRole('slider');
+    expect(slider).toHaveAttribute('aria-valuenow', '100');
+
+    // verify the change handlers for the components is not invoked on mount
+    const { splitMetadata: { entitiesToSplit } } = defaultProps;
+    entitiesToSplit.forEach(entity => expect(entity.handleChange).not.toHaveBeenCalled());
+
+    // shift focus to the slider and hit left arrow key to set transfer and wage budget values
+    slider.focus();
+    // userEvent does not support keyboard events in this version of react-testing-library
+    // so using fireEvent instead
+    fireEvent.keyDown(document.activeElement, { key: 'ArrowLeft' });
+    expect(slider).toHaveAttribute('aria-valuenow', '99');
+
+    // verify the change handlers are now called
+    entitiesToSplit.forEach(entity => expect(entity.handleChange).toHaveBeenCalled());
+});
+
+it('rerendering with different prop values updates the internal state', () => {
+    const { rerender } = render(<CustomSlider {...defaultProps} />);
+
+    const updatedValueToSplit = 200;
+    const updatedProps = {
+        ...defaultProps,
+        splitMetadata: {
+            ...defaultProps.splitMetadata,
+            valueToSplit: updatedValueToSplit
+        }
+    };
+    rerender(<CustomSlider {...updatedProps} />);
+
+    // since the initial percentage is 100% and has not changed, the first component's change handler should be called
+    // with a value equal to the value to split passed in the props
+    const { splitMetadata: { entitiesToSplit } } = updatedProps;
+    entitiesToSplit.forEach(entity => expect(entity.handleChange).toHaveBeenCalled());
+    expect(entitiesToSplit[0].handleChange).toHaveBeenCalledWith({
+        target: { name: entitiesToSplit[0].name, value: updatedValueToSplit }
+    });
+});

--- a/dashboard-ui/src/hooks/useAddNewClub.js
+++ b/dashboard-ui/src/hooks/useAddNewClub.js
@@ -15,10 +15,15 @@ export default function () {
 
     return {
         addNewClubAction: async newClubData => {
-            const { income, expenditure, ...rest } = newClubData;
+            const { income, expenditure, managerFunds, ...rest } = newClubData;
             try {
                 await mutateAsync({
-                    newClubData: { ...rest, income: { current: income }, expenditure: { current: expenditure } },
+                    newClubData: {
+                        ...rest,
+                        income: { current: Number(income) },
+                        expenditure: { current: Number(expenditure) },
+                        managerFunds: Number(managerFunds)
+                    },
                     authToken: authData.id
                 });
             } catch (err) {

--- a/dashboard-ui/src/hooks/useAddNewClub.js
+++ b/dashboard-ui/src/hooks/useAddNewClub.js
@@ -15,8 +15,12 @@ export default function () {
 
     return {
         addNewClubAction: async newClubData => {
+            const { income, expenditure, ...rest } = newClubData;
             try {
-                await mutateAsync({ newClubData, authToken: authData.id });
+                await mutateAsync({
+                    newClubData: { ...rest, income: { current: income }, expenditure: { current: expenditure } },
+                    authToken: authData.id
+                });
             } catch (err) {
                 if (err instanceof Error) {
                     return err.message;

--- a/dashboard-ui/src/hooks/useForm.js
+++ b/dashboard-ui/src/hooks/useForm.js
@@ -36,16 +36,16 @@ const useForm = (defaultFormValues, callback) => {
         } else {
             setSubmitStatus(formSubmission.NOT_READY);
         }
-        setFormValidations({
+        setFormValidations(formValidations => ({
             ...formValidations,
             [name]: validation || null
-        });
+        }));
 
         // update form field data
-        setFormData({
+        setFormData(formData => ({
             ...formData,
             [name]: value
-        });
+        }));
     };
 
     const handleSubmitFn = e => {

--- a/dashboard-ui/src/hooks/useForm.js
+++ b/dashboard-ui/src/hooks/useForm.js
@@ -55,7 +55,6 @@ const useForm = (defaultFormValues, callback) => {
         async authAction => {
             const formErrorMessage = await authAction(formData);
             if (formErrorMessage != null) {
-                setSubmitStatus(formSubmission.NOT_READY);
                 setFormValidations(formValidations => ({
                     ...formValidations,
                     form: formErrorMessage

--- a/dashboard-ui/src/hooks/useForm.js
+++ b/dashboard-ui/src/hooks/useForm.js
@@ -1,9 +1,8 @@
 import { useState, useCallback, useEffect } from 'react';
 
-import { capitalizeLabel, convertCamelCaseToSnakeCase, formSubmission } from '../utils';
+import { capitalizeLabel, formSubmission } from '../utils';
 
-const getEmptyFieldValidation = fieldName =>
-    `${capitalizeLabel(convertCamelCaseToSnakeCase(fieldName))} cannot be empty!`;
+const getEmptyFieldValidation = fieldName => `${capitalizeLabel(fieldName, 'camelcase')} cannot be empty!`;
 const validateEmail = email => /\S+@\S+\.\S+/.test(email);
 const validatePlayerAge = playerAge => parseInt(playerAge) >= 15 && parseInt(playerAge) <= 50;
 

--- a/dashboard-ui/src/hooks/useForm.js
+++ b/dashboard-ui/src/hooks/useForm.js
@@ -27,15 +27,7 @@ const useForm = (defaultFormValues, callback) => {
 
         // validate the input
         const validation = validateInput(name, value, formData);
-        if (!validation) {
-            // the current validation returned as falsy, so set submit status to READY if the remaining fields do not
-            // have any validations either
-            if (Object.values(formValidations).filter(validation => validation === null).length === (numFields - 1)) {
-                setSubmitStatus(formSubmission.READY);
-            }
-        } else {
-            setSubmitStatus(formSubmission.NOT_READY);
-        }
+
         setFormValidations(formValidations => ({
             ...formValidations,
             [name]: validation || null
@@ -81,7 +73,17 @@ const useForm = (defaultFormValues, callback) => {
         if (submitStatus === formSubmission.INPROGRESS) {
             postFormData(callback);
         }
-    }, [formValidations, submitStatus, callback, postFormData]);
+    }, [submitStatus, callback, postFormData]);
+
+    useEffect(() => {
+        const numFieldsWithNoValidations = Object.values(formValidations)
+            .filter(validation => validation === null).length;
+        if (numFieldsWithNoValidations === numFields) {
+            setSubmitStatus(formSubmission.READY);
+        } else {
+            setSubmitStatus(formSubmission.NOT_READY);
+        }
+    }, [formValidations]);
 
     return {
         handleChangeFn,

--- a/dashboard-ui/src/hooks/useForm.test.js
+++ b/dashboard-ui/src/hooks/useForm.test.js
@@ -17,7 +17,7 @@ describe('useForm hook -', () => {
                 formValidations: { firstName: firstNameEmptyValidation }
             } = result.current;
             expect(firstNameEmptyValidation).toBeDefined();
-            expect(firstNameEmptyValidation).toEqual('First Name cannot be empty!');
+            expect(firstNameEmptyValidation).toBe('First Name cannot be empty!');
 
             // the validations are reset when correct values are passed in.
             act(() => {
@@ -28,7 +28,7 @@ describe('useForm hook -', () => {
                 submitStatus
             } = result.current;
             expect(firstNameValidation).toBeNull();
-            expect(submitStatus).toEqual(formSubmission.READY);
+            expect(submitStatus).toBe(formSubmission.READY);
         });
 
         it('validates email format', async () => {
@@ -43,7 +43,7 @@ describe('useForm hook -', () => {
                 formValidations: { email: emailFormatValidation }
             } = result.current;
             expect(emailFormatValidation).toBeDefined();
-            expect(emailFormatValidation).toEqual('Email format is incorrect!');
+            expect(emailFormatValidation).toBe('Email format is incorrect!');
 
             // the validations are reset when correct values are passed in.
             act(() => {
@@ -68,7 +68,7 @@ describe('useForm hook -', () => {
                 formValidations: { newPassword: passwordLengthValidation }
             } = result.current;
             expect(passwordLengthValidation).toBeDefined();
-            expect(passwordLengthValidation).toEqual('Password must be between 6 and 12 characters');
+            expect(passwordLengthValidation).toBe('Password must be between 6 and 12 characters');
 
             // the validations are reset when correct values are passed in.
             act(() => {
@@ -95,7 +95,7 @@ describe('useForm hook -', () => {
                 formValidations: { confirmedPassword: passwordNotMatchingValidation }
             } = result.current;
             expect(passwordNotMatchingValidation).toBeDefined();
-            expect(passwordNotMatchingValidation).toEqual('Passwords must match!');
+            expect(passwordNotMatchingValidation).toBe('Passwords must match!');
 
             // the validations are reset when correct values are passed in.
             act(() => {
@@ -178,14 +178,14 @@ describe('useForm hook -', () => {
 
             const { result, waitForNextUpdate } = renderHook(() => useForm({ firstName: '' }, mockCallback));
             const { handleChangeFn, submitStatus } = result.current;
-            expect(submitStatus).toEqual(formSubmission.NOT_READY);
+            expect(submitStatus).toBe(formSubmission.NOT_READY);
 
             act(() => {
                 handleChangeFn({ target: { name: 'firstName', value: 'fake first name' } });
             });
 
             const { handleSubmitFn, submitStatus: submitStatusAfterFieldUpdate } = result.current;
-            expect(submitStatusAfterFieldUpdate).toEqual(formSubmission.READY);
+            expect(submitStatusAfterFieldUpdate).toBe(formSubmission.READY);
 
             act(() => {
                 handleSubmitFn({ preventDefault: jest.fn() });
@@ -194,7 +194,7 @@ describe('useForm hook -', () => {
             expect(mockCallback).toBeCalledTimes(1);
 
             const { submitStatus: submitStatusAfterClientCall } = result.current;
-            expect(submitStatusAfterClientCall).toEqual(formSubmission.COMPLETE);
+            expect(submitStatusAfterClientCall).toBe(formSubmission.COMPLETE);
         });
 
         it('form submit status is not changed to COMPLETE if client returns error', async () => {
@@ -203,7 +203,7 @@ describe('useForm hook -', () => {
 
             const { result, waitForNextUpdate } = renderHook(() => useForm({ firstName: '' }, mockCallback));
             const { handleChangeFn, submitStatus } = result.current;
-            expect(submitStatus).toEqual(formSubmission.NOT_READY);
+            expect(submitStatus).toBe(formSubmission.NOT_READY);
 
             act(() => {
                 handleChangeFn({ target: { name: 'firstName', value: 'fake first name' } });
@@ -218,7 +218,7 @@ describe('useForm hook -', () => {
 
             const { formValidations, submitStatus: submitStatusAfterClientCall } = result.current;
             expect(formValidations.form).toBeDefined();
-            expect(formValidations.form).toEqual('Something went wrong!');
+            expect(formValidations.form).toBe('Something went wrong!');
 
             // submit status is changed from INPROGRESS to null again because there is an error on the form now
             expect(submitStatusAfterClientCall).not.toBe(formSubmission.COMPLETE);

--- a/dashboard-ui/src/hooks/useForm.test.js
+++ b/dashboard-ui/src/hooks/useForm.test.js
@@ -32,7 +32,7 @@ describe('useForm hook -', () => {
         });
 
         it('validates email format', async () => {
-            const { result } = renderHook(() => useForm({ email: '', password: '' }, jest.fn()));
+            const { result } = renderHook(() => useForm({ email: '' }, jest.fn()));
             const { handleChangeFn, formValidations } = result.current;
             expect(formValidations.email).toBeUndefined();
 
@@ -56,7 +56,7 @@ describe('useForm hook -', () => {
         });
 
         it('validates password length', async () => {
-            const { result } = renderHook(() => useForm({ email: '', newPassword: '' }, jest.fn()));
+            const { result } = renderHook(() => useForm({ newPassword: '' }, jest.fn()));
             const { handleChangeFn, formValidations } = result.current;
             expect(formValidations.newPassword).toBeUndefined();
 
@@ -82,7 +82,7 @@ describe('useForm hook -', () => {
 
         it('validates that passwords are matching', async () => {
             const { result } = renderHook(() =>
-                useForm({ email: '', newPassword: '123456', confirmedPassword: '' }, jest.fn())
+                useForm({ newPassword: '123456', confirmedPassword: '' }, jest.fn())
             );
             const { handleChangeFn, formValidations } = result.current;
             expect(formValidations.confirmedPassword).toBeUndefined();

--- a/dashboard-ui/src/hooks/useForm.test.js
+++ b/dashboard-ui/src/hooks/useForm.test.js
@@ -106,6 +106,45 @@ describe('useForm hook -', () => {
             } = result.current;
             expect(passwordMatchingValidation).toBeNull();
         });
+
+        it('validates form data with multiple fields', async () => {
+            const { result } = renderHook(() => useForm({ firstName: '', lastName: '' }, jest.fn()));
+            const { handleChangeFn, formValidations } = result.current;
+            expect(formValidations.firstName).toBeUndefined();
+            expect(formValidations.lastName).toBeUndefined();
+
+            act(() => {
+                handleChangeFn({ target: { name: 'firstName', value: 'fake first name' } });
+            });
+            const {
+                formValidations: { firstName: firstNameValidation }
+            } = result.current;
+            expect(firstNameValidation).toBeDefined();
+            expect(result.current.submitStatus).toBe(formSubmission.NOT_READY);
+
+            // updating the same field with valid input should result in the same state as before
+            const { handleChangeFn: handleChangeOnFirstNameUpdate } = result.current;
+            act(() => {
+                handleChangeOnFirstNameUpdate({ target: { name: 'firstName', value: 'updated fake first name' } });
+            });
+            const {
+                formValidations: { firstName: updatedFirstNameValidation }
+            } = result.current;
+            expect(updatedFirstNameValidation).toBeDefined();
+            expect(result.current.submitStatus).toBe(formSubmission.NOT_READY);
+
+            // updating the last field in the form with valid input should result in the form submit status to change
+            // to READY
+            const { handleChangeFn: handleChangeOnLastNameInput } = result.current;
+            act(() => {
+                handleChangeOnLastNameInput({ target: { name: 'lastName', value: 'fake last name' } });
+            });
+            const {
+                formValidations: { lastName: lastNameValidation }
+            } = result.current;
+            expect(lastNameValidation).toBeDefined();
+            expect(result.current.submitStatus).toBe(formSubmission.READY);
+        });
     });
 
     describe('handle form submission', () => {

--- a/dashboard-ui/src/hooks/useForm.test.js
+++ b/dashboard-ui/src/hooks/useForm.test.js
@@ -221,7 +221,7 @@ describe('useForm hook -', () => {
             expect(formValidations.form).toEqual('Something went wrong!');
 
             // submit status is changed from INPROGRESS to null again because there is an error on the form now
-            expect(submitStatusAfterClientCall).toEqual(formSubmission.NOT_READY);
+            expect(submitStatusAfterClientCall).not.toBe(formSubmission.COMPLETE);
         });
     });
 });

--- a/dashboard-ui/src/hooks/useForm.test.js
+++ b/dashboard-ui/src/hooks/useForm.test.js
@@ -20,8 +20,9 @@ describe('useForm hook -', () => {
             expect(firstNameEmptyValidation).toBe('First Name cannot be empty!');
 
             // the validations are reset when correct values are passed in.
+            const { handleChangeFn: handleChangeOnFixingFirstName } = result.current;
             act(() => {
-                handleChangeFn({ target: { name: 'firstName', value: 'fake first name' } });
+                handleChangeOnFixingFirstName({ target: { name: 'firstName', value: 'fake first name' } });
             });
             const {
                 formValidations: { firstName: firstNameValidation },
@@ -46,8 +47,9 @@ describe('useForm hook -', () => {
             expect(emailFormatValidation).toBe('Email format is incorrect!');
 
             // the validations are reset when correct values are passed in.
+            const { handleChangeFn: handleChangeOnFixingEmail } = result.current;
             act(() => {
-                handleChangeFn({ target: { name: 'email', value: 'fake@email.com' } });
+                handleChangeOnFixingEmail({ target: { name: 'email', value: 'fake@email.com' } });
             });
             const {
                 formValidations: { email: emailValidation }
@@ -71,8 +73,9 @@ describe('useForm hook -', () => {
             expect(passwordLengthValidation).toBe('Password must be between 6 and 12 characters');
 
             // the validations are reset when correct values are passed in.
+            const { handleChangeFn: handleChangeOnFixingPassword } = result.current;
             act(() => {
-                handleChangeFn({ target: { name: 'newPassword', value: '123456' } });
+                handleChangeOnFixingPassword({ target: { name: 'newPassword', value: '123456' } });
             });
             const {
                 formValidations: { newPassword: passwordValidation }
@@ -98,8 +101,9 @@ describe('useForm hook -', () => {
             expect(passwordNotMatchingValidation).toBe('Passwords must match!');
 
             // the validations are reset when correct values are passed in.
+            const { handleChangeFn: handleChangeOnFixingPassword } = result.current;
             act(() => {
-                handleChangeFn({ target: { name: 'confirmedPassword', value: '123456' } });
+                handleChangeOnFixingPassword({ target: { name: 'confirmedPassword', value: '123456' } });
             });
             const {
                 formValidations: { confirmedPassword: passwordMatchingValidation }

--- a/dashboard-ui/src/pages/Home.test.js
+++ b/dashboard-ui/src/pages/Home.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { QueryClient, QueryClientProvider } from 'react-query';
@@ -52,13 +52,25 @@ it('should render success message when add new club form is submitted', async ()
     expect(screen.queryByRole('dialog')).toBeInTheDocument();
 
     const inputValue = 'Aston Villa FC';
+    const managerFundsValue = '100';
     userEvent.type(screen.getByLabelText(/club name/i), inputValue);
-    userEvent.type(screen.getByLabelText(/transfer budget/i), '1');
-    userEvent.type(screen.getByLabelText(/wage budget/i), '1');
+    userEvent.type(screen.getByLabelText(/manager funds/i), managerFundsValue);
+
+    // verify that the initial value on the slider gets set when manager funds is changed above
+    const slider = screen.getByRole('slider');
+    expect(slider).toHaveAttribute('aria-valuenow', managerFundsValue);
+
+    // shift focus to the slider and hit left arrow key to set transfer and wage budget values
+    slider.focus();
+    // userEvent does not support keyboard events in this version of react-testing-library
+    // so using fireEvent instead
+    fireEvent.keyDown(document.activeElement, { key: 'ArrowLeft' });
+
     userEvent.type(screen.getByLabelText(/income/i), '1');
     userEvent.type(screen.getByLabelText(/expenditure/i), '1');
 
     const submitButton = screen.getByRole('button', { name: 'Submit' });
+    expect(submitButton).not.toBeDisabled();
     userEvent.click(submitButton);
 
     await screen.findByText('New Club Added Successfully!');

--- a/dashboard-ui/src/pages/Home.test.js
+++ b/dashboard-ui/src/pages/Home.test.js
@@ -52,15 +52,11 @@ it('should render success message when add new club form is submitted', async ()
     expect(screen.queryByRole('dialog')).toBeInTheDocument();
 
     const inputValue = 'Aston Villa FC';
-    const managerFundsValue = '100';
     userEvent.type(screen.getByLabelText(/club name/i), inputValue);
-    userEvent.type(screen.getByLabelText(/manager funds/i), managerFundsValue);
-
-    // verify that the initial value on the slider gets set when manager funds is changed above
-    const slider = screen.getByRole('slider');
-    expect(slider).toHaveAttribute('aria-valuenow', managerFundsValue);
+    userEvent.type(screen.getByLabelText(/manager funds/i), '10');
 
     // shift focus to the slider and hit left arrow key to set transfer and wage budget values
+    const slider = screen.getByRole('slider');
     slider.focus();
     // userEvent does not support keyboard events in this version of react-testing-library
     // so using fireEvent instead

--- a/dashboard-ui/src/stories/CustomSlider.stories.js
+++ b/dashboard-ui/src/stories/CustomSlider.stories.js
@@ -1,0 +1,24 @@
+import CustomSlider from '../components/CustomSlider';
+import { action } from '@storybook/addon-actions';
+
+export default {
+    component: CustomSlider,
+    title: 'Components/Globals/CustomSlider'
+};
+
+const Template = args => <CustomSlider {...args}/>;
+
+export const Default = Template.bind({});
+Default.args = {
+    sliderTitle: 'Slider Title',
+    splitMetadata: {
+        valueToSplit: 2000000,
+        entitiesToSplit: [{
+            name: 'transferBudget',
+            handleChange: action('Update Transfer Budget')
+        }, {
+            name: 'wageBudget',
+            handleChange: action('Update Wage Budget')
+        }]
+    }
+};

--- a/dashboard-ui/src/utils.js
+++ b/dashboard-ui/src/utils.js
@@ -147,5 +147,8 @@ export const stableSortList = (array, sortOrder, columnNameToOrderBy) => {
 export const convertCamelCaseToSnakeCase = camelCaseString =>
     camelCaseString.replace(/([a-z])([A-Z])/g, '$1_$2').toLowerCase();
 
+export const formatNumberWithCommas = number =>
+    number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+
 // key for storing the auth token data in localstorage
 export const AUTH_DATA_LS_KEY = 'auth-data';

--- a/dashboard-ui/src/utils.js
+++ b/dashboard-ui/src/utils.js
@@ -75,9 +75,14 @@ export const formSubmission = {
     INPROGRESS: 'INPROGRESS'
 };
 
-export const capitalizeLabel = label => {
-    return label
-        .split('_')
+export const capitalizeLabel = (label, format = 'snakecase') => {
+    let tokens;
+    if (format === 'snakecase') {
+        tokens = label.split('_');
+    } else {
+        tokens = label.replace(/([a-z])([A-Z])/g, '$1 $2').toLowerCase().split(' ');
+    }
+    return tokens
         .map(word => word[0].toUpperCase() + word.slice(1))
         .join(' ');
 };

--- a/dashboard-ui/src/widgets/AddClub.js
+++ b/dashboard-ui/src/widgets/AddClub.js
@@ -10,6 +10,7 @@ import PageAction from '../components/PageAction';
 
 import { formSubmission } from '../utils';
 import useForm from '../hooks/useForm';
+import CustomSlider from '../components/CustomSlider';
 
 export default function AddClub({ addClubAction }) {
     const {
@@ -21,10 +22,11 @@ export default function AddClub({ addClubAction }) {
     } = useForm(
         {
             name: '',
-            transferBudget: 0,
-            wageBudget: 0,
-            income: 0,
-            expenditure: 0
+            managerFunds: '0',
+            transferBudget: '0',
+            wageBudget: '0',
+            income: '0',
+            expenditure: '0'
         },
         useCallback(newClubData => addClubAction(newClubData), [])
     );
@@ -52,37 +54,30 @@ export default function AddClub({ addClubAction }) {
                 helperText={addNewClubValidations.name}
             />
             <TextField
-                name='transferBudget'
-                label='Transfer Budget'
+                name='managerFunds'
+                label='Manager Funds'
                 required
-                id='transferBudget'
+                id='managerFunds'
                 type='number'
                 margin='normal'
                 fullWidth
-                value={addNewClubData.transferBudget}
+                value={addNewClubData.managerFunds}
                 disabled={submitStatus === formSubmission.INPROGRESS}
                 onChange={e => handleChangeFn(e)}
-                error={!!addNewClubValidations.transferBudget}
-                helperText={addNewClubValidations.transferBudget}
+                error={!!addNewClubValidations.managerFunds}
+                helperText={addNewClubValidations.managerFunds}
                 InputProps={{
                     startAdornment: <InputAdornment position='start'>$</InputAdornment>
                 }}
             />
-            <TextField
-                name='wageBudget'
-                label='Wage Budget'
-                required
-                id='wageBudget'
-                type='number'
-                margin='normal'
-                fullWidth
-                value={addNewClubData.wageBudget}
-                disabled={submitStatus === formSubmission.INPROGRESS}
-                onChange={e => handleChangeFn(e)}
-                error={!!addNewClubValidations.wageBudget}
-                helperText={addNewClubValidations.wageBudget}
-                InputProps={{
-                    startAdornment: <InputAdornment position='start'>$</InputAdornment>
+            <CustomSlider
+                sliderTitle='Budget Split'
+                splitMetadata={{
+                    valueToSplit: addNewClubData.managerFunds,
+                    entitiesToSplit: [
+                        { name: 'transferBudget', handleChange: handleChangeFn },
+                        { name: 'wageBudget', handleChange: handleChangeFn },
+                    ]
                 }}
             />
             <TextField

--- a/dashboard-ui/src/widgets/AddClub.js
+++ b/dashboard-ui/src/widgets/AddClub.js
@@ -73,7 +73,7 @@ export default function AddClub({ addClubAction }) {
             <CustomSlider
                 sliderTitle='Budget Split'
                 splitMetadata={{
-                    valueToSplit: addNewClubData.managerFunds,
+                    valueToSplit: Number(addNewClubData.managerFunds),
                     entitiesToSplit: [
                         { name: 'transferBudget', handleChange: handleChangeFn },
                         { name: 'wageBudget', handleChange: handleChangeFn },

--- a/dashboard-ui/src/widgets/AddPlayer.js
+++ b/dashboard-ui/src/widgets/AddPlayer.js
@@ -11,7 +11,7 @@ import Alert from '../components/Alert';
 import DialogForm from '../components/DialogForm';
 import PageAction from '../components/PageAction';
 
-import { capitalizeLabel, convertCamelCaseToSnakeCase } from '../utils';
+import { capitalizeLabel } from '../utils';
 import useFormWithSteps from '../hooks/useFormWithSteps';
 import AddPlayerForm, { getAddPlayerFormSchema, getStepper } from './AddPlayerForm';
 
@@ -51,7 +51,7 @@ export default function AddPlayer({ addPlayerAction }) {
                 <>
                     <Typography variant='h5' align='center'>Confirm Details</Typography>
                     {Object.entries(nestedFormData).map(([sectionName, formDataInSection]) => {
-                        const sectionTitle = capitalizeLabel(convertCamelCaseToSnakeCase(sectionName));
+                        const sectionTitle = capitalizeLabel(sectionName, 'camelcase');
                         return (
                             <>
                                 <Typography variant='h6' color='textSecondary'>{sectionTitle}</Typography>
@@ -59,7 +59,8 @@ export default function AddPlayer({ addPlayerAction }) {
                                 <List key={sectionName}>
                                     {Object.entries(formDataInSection).map(([fieldName, fieldValue]) => {
                                         const formDataText = `${capitalizeLabel(
-                                            convertCamelCaseToSnakeCase(fieldName)
+                                            fieldName,
+                                            'camelcase'
                                         )}: ${fieldValue}`;
                                         return (
                                             // TODO: figure out how to display this as field name aligned to the left

--- a/dashboard-ui/src/widgets/AddPlayerForm.js
+++ b/dashboard-ui/src/widgets/AddPlayerForm.js
@@ -203,7 +203,7 @@ const PlayerAttributeForm = ({ newPlayerAttributeData, newPlayerAttributeValidat
                 autoFocus={index === 0}
                 key={attrDataName}
                 name={attrDataName}
-                label={capitalizeLabel(attrDataName)}
+                label={capitalizeLabel(attrDataName, 'camelcase')}
                 required
                 id={attrDataName}
                 type='number'


### PR DESCRIPTION
## Motivation and Context
The club creation endpoint now expects a new property `managerFunds`. Since this changes the business logic, such that `transferBudget` and `wageBudget` are now to be derived from `managerFunds`, a new slider component has been added in this PR. Finally, the Add Club form has been updated to include a field for the new property and integrated the slider to split the funds into transfer and wage budgets. This PR resolves #105

Some additional changes made in this PR that are not related to #105 include:
* Modifying the `useForm` hook to separate the form validation logic from the submit status setting logic.
* Updating the `capitalizeLabel` util method to handle multiple formats like _camel case_ and _snake case_.
* Fixing an issue with `useForm` hook's `handleChangeFn` method to work correctly even if multiple calls are made to it asynchronously.

## How Has This Been Tested?
Tests have been added for the new slider component to verify the following scenarios:
* Internal state and change handler for the components to be split is only invoked on user action.
* Changing the value to split (manager funds in this case) leads to the component being re-rendered with an update to the internal state and change handlers being invoked.
* Adjusting the slider, updates the components being split (transfer and wage budget in this case)

Existing tests for the Add Club form widget have been updated to work with the new field and custom slider integration.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
