### PR TITLE
Add validation layer in backend server

### DIFF
--- a/dashboard-server/src/main/java/com/footballstatsdashboard/FootballDashboardApplication.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/FootballDashboardApplication.java
@@ -3,6 +3,7 @@ package com.footballstatsdashboard;
 import com.footballstatsdashboard.api.model.User;
 import com.footballstatsdashboard.client.couchbase.CouchbaseClientManager;
 import com.footballstatsdashboard.client.couchbase.config.ClusterConfiguration;
+import com.footballstatsdashboard.core.exceptions.ServiceExceptionMapper;
 import com.footballstatsdashboard.core.service.auth.CustomAuthenticator;
 import com.footballstatsdashboard.core.service.auth.CustomAuthorizer;
 import com.footballstatsdashboard.core.utils.DashboardInternalModule;
@@ -125,7 +126,9 @@ public class FootballDashboardApplication extends Application<FootballDashboardC
         // setup health checks
         environment.healthChecks().register(this.getName(), new FootballDashboardHealthCheck());
 
-        // add exception mapper so that json errors are show in detail
+        // setup exception mappers
+        environment.jersey().register(new ServiceExceptionMapper());
+        // this ensures json errors are shown in detail
         environment.jersey().register(new JsonProcessingExceptionMapper(true));
 
         LOGGER.info("All resources added for {}", getName());

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/Player.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/api/model/Player.java
@@ -8,15 +8,13 @@ import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import com.footballstatsdashboard.api.model.player.Ability;
 import com.footballstatsdashboard.api.model.player.Attribute;
+import com.footballstatsdashboard.api.model.player.Metadata;
 import com.footballstatsdashboard.api.model.player.Role;
 import com.footballstatsdashboard.core.utils.InternalField;
 import org.immutables.value.Value;
 
-import com.footballstatsdashboard.api.model.player.Metadata;
-
 import javax.annotation.Nullable;
 import javax.validation.Valid;
-import javax.validation.constraints.Size;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
@@ -60,7 +58,6 @@ public interface Player {
      * Information about the player's attributes
      */
     @Valid
-    @Size(min = 1)
     List<Attribute> getAttributes();
 
     /**

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/core/exceptions/ServiceException.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/core/exceptions/ServiceException.java
@@ -1,0 +1,67 @@
+package com.footballstatsdashboard.core.exceptions;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.footballstatsdashboard.core.validations.Validation;
+import io.dropwizard.jackson.Jackson;
+import org.eclipse.jetty.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ServiceException extends RuntimeException {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServiceException.class);
+    private static final ObjectMapper OBJECT_MAPPER = Jackson.newObjectMapper().copy();
+
+    private final String responseBody;
+    private final int responseStatus;
+    private List<Validation> validationList;
+
+    public ServiceException(int responseStatus, String message) {
+        super(message);
+        this.responseStatus = responseStatus;
+        this.responseBody = getCustomResponseBody();
+    }
+
+    public ServiceException(int responseStatus, String message, List<Validation> validationList) {
+        super(message);
+        this.responseStatus = responseStatus;
+        this.validationList = validationList;
+        this.responseBody = getCustomResponseBody();
+    }
+
+    public String getResponseBody() {
+        return this.responseBody;
+    }
+
+    public int getResponseStatus() {
+        return responseStatus;
+    }
+
+    public List<Validation> getValidationList() {
+        return validationList;
+    }
+
+    private String getCustomResponseBody() {
+        if (StringUtil.isBlank(this.getMessage())) {
+            return null;
+        }
+        Map<String, Object> params = new HashMap<>();
+        params.put("status", this.getResponseStatus());
+        params.put("message", this.getMessage());
+
+        if (this.getValidationList() != null) {
+            params.put("validations", this.getValidationList());
+        }
+
+        try {
+            return OBJECT_MAPPER.writeValueAsString(params);
+        } catch (JsonProcessingException ex) {
+            LOGGER.warn("Unable to serialize params map to string!", ex);
+            return null;
+        }
+    }
+}

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/core/exceptions/ServiceException.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/core/exceptions/ServiceException.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.footballstatsdashboard.core.validations.Validation;
 import io.dropwizard.jackson.Jackson;
-import org.eclipse.jetty.util.StringUtil;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +46,7 @@ public class ServiceException extends RuntimeException {
     }
 
     private String getCustomResponseBody() {
-        if (StringUtil.isBlank(this.getMessage())) {
+        if (StringUtils.isBlank(this.getMessage())) {
             return null;
         }
         Map<String, Object> params = new HashMap<>();

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/core/exceptions/ServiceExceptionMapper.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/core/exceptions/ServiceExceptionMapper.java
@@ -1,0 +1,17 @@
+package com.footballstatsdashboard.core.exceptions;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class ServiceExceptionMapper implements ExceptionMapper<ServiceException> {
+
+    @Override
+    public Response toResponse(ServiceException serviceException) {
+        String exceptionMessage = serviceException.getResponseBody() != null
+                ? serviceException.getResponseBody() : serviceException.getMessage();
+        return Response
+                .status(serviceException.getResponseStatus())
+                .entity(exceptionMessage)
+                .build();
+    }
+}

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/core/validations/Validation.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/core/validations/Validation.java
@@ -1,0 +1,24 @@
+package com.footballstatsdashboard.core.validations;
+
+public class Validation {
+    private final ValidationSeverity validationSeverity;
+    private final String message;
+
+    public Validation(ValidationSeverity validationSeverity, String message) {
+        this.validationSeverity = validationSeverity;
+        this.message = message;
+    }
+
+    public ValidationSeverity getValidationSeverity() {
+        return validationSeverity;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s: %s", this.getValidationSeverity(), this.getMessage());
+    }
+}

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/core/validations/ValidationSeverity.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/core/validations/ValidationSeverity.java
@@ -1,0 +1,6 @@
+package com.footballstatsdashboard.core.validations;
+
+public enum ValidationSeverity {
+    WARNING,
+    ERROR
+}

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
@@ -43,7 +43,7 @@ public class ClubService {
 
     public Club createClub(Club incomingClub, UUID userId, String createdBy) {
         List<Validation> validationList = validateIncomingClub(incomingClub, true);
-        if (validationList.size() > 0) {
+        if (!validationList.isEmpty()) {
             LOGGER.error("Unable to create new club! Found errors: {}", validationList);
             throw new ServiceException(HttpStatus.UNPROCESSABLE_ENTITY_422, "Invalid incoming club data.",
                     validationList);
@@ -85,7 +85,7 @@ public class ClubService {
 
     public Club updateClub(Club incomingClub, Club existingClub, UUID existingClubId) {
         List<Validation> validationList = validateIncomingClub(incomingClub, false);
-        if (validationList.size() > 0) {
+        if (!validationList.isEmpty()) {
             LOGGER.error("Unable to update club! Found errors: {}", validationList);
             throw new ServiceException(HttpStatus.UNPROCESSABLE_ENTITY_422, "Invalid incoming club entity.",
                     validationList);

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
@@ -45,11 +45,11 @@ public class ClubService {
         List<Validation> validationList = validateIncomingClub(incomingClub, true);
         if (validationList.size() > 0) {
             LOGGER.error("Unable to create new club! Found errors: {}", validationList);
-            throw new ServiceException(HttpStatus.UNPROCESSABLE_ENTITY_422, "Invalid incoming club entity.",
+            throw new ServiceException(HttpStatus.UNPROCESSABLE_ENTITY_422, "Invalid incoming club data.",
                     validationList);
         }
 
-        // process and persist the club if no validations found
+        // process and persist the club data if no validations found
         ManagerFunds newManagerFunds = ImmutableManagerFunds.builder()
                 .from(incomingClub.getManagerFunds())
                 .history(Collections.singletonList(incomingClub.getManagerFunds().getCurrent()))

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
@@ -10,17 +10,26 @@ import com.footballstatsdashboard.api.model.club.ImmutableManagerFunds;
 import com.footballstatsdashboard.api.model.club.Income;
 import com.footballstatsdashboard.api.model.club.ManagerFunds;
 import com.footballstatsdashboard.api.model.club.SquadPlayer;
+import com.footballstatsdashboard.core.exceptions.ServiceException;
+import com.footballstatsdashboard.core.validations.Validation;
+import com.footballstatsdashboard.core.validations.ValidationSeverity;
 import com.footballstatsdashboard.db.ClubDAO;
 import com.footballstatsdashboard.db.key.ResourceKey;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jetty.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
 public class ClubService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClubService.class);
     private final ClubDAO<ResourceKey> clubDAO;
 
     public ClubService(ClubDAO<ResourceKey> clubDAO) {
@@ -33,6 +42,14 @@ public class ClubService {
     }
 
     public Club createClub(Club incomingClub, UUID userId, String createdBy) {
+        List<Validation> validationList = validateIncomingClub(incomingClub, true);
+        if (validationList.size() > 0) {
+            LOGGER.error("Unable to create new club! Found errors: {}", validationList);
+            throw new ServiceException(HttpStatus.UNPROCESSABLE_ENTITY_422, "Invalid incoming club entity.",
+                    validationList);
+        }
+
+        // process and persist the club if no validations found
         ManagerFunds newManagerFunds = ImmutableManagerFunds.builder()
                 .from(incomingClub.getManagerFunds())
                 .history(Collections.singletonList(incomingClub.getManagerFunds().getCurrent()))
@@ -67,6 +84,14 @@ public class ClubService {
     }
 
     public Club updateClub(Club incomingClub, Club existingClub, UUID existingClubId) {
+        List<Validation> validationList = validateIncomingClub(incomingClub, false);
+        if (validationList.size() > 0) {
+            LOGGER.error("Unable to update club! Found errors: {}", validationList);
+            throw new ServiceException(HttpStatus.UNPROCESSABLE_ENTITY_422, "Invalid incoming club entity.",
+                    validationList);
+        }
+
+        // process and update the club data if no validations are found
         ImmutableClub.Builder updatedClubBuilder = ImmutableClub.builder()
                 .from(existingClub);
 
@@ -107,5 +132,30 @@ public class ClubService {
 
     public List<SquadPlayer> getSquadPlayers(UUID clubId) {
         return this.clubDAO.getPlayersInClub(clubId);
+    }
+
+    private List<Validation> validateIncomingClub(Club incomingClub, boolean isForNewClub) {
+        List<Validation> validationList = new ArrayList<>();
+        if (isForNewClub) {
+            if (StringUtils.isEmpty(incomingClub.getName())) {
+                validationList.add(new Validation(ValidationSeverity.ERROR, "Empty club name is not allowed!"));
+            }
+
+            if (incomingClub.getIncome() == null) {
+                validationList.add(new Validation(ValidationSeverity.ERROR, "New club must have income data!"));
+            }
+
+            if (incomingClub.getExpenditure() == null) {
+                validationList.add(new Validation(ValidationSeverity.ERROR, "New club must have expenditure data!"));
+            }
+        }
+
+        BigDecimal totalBudget = incomingClub.getTransferBudget().add(incomingClub.getWageBudget());
+        if (totalBudget.compareTo(incomingClub.getManagerFunds().getCurrent()) != 0) {
+            validationList.add(new Validation(ValidationSeverity.ERROR,
+                    "Transfer and wage budget must add up to manager funds!"));
+        }
+
+        return validationList;
     }
 }

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/PlayerService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/PlayerService.java
@@ -147,21 +147,16 @@ public class PlayerService {
 
         // process and persist the player data if no validations found
         List<Attribute> updatedPlayerAttributes = incomingPlayer.getAttributes().stream()
-                .map(incomingAttribute -> {
-                    Attribute existingPlayerAttribute = existingPlayer.getAttributes().stream()
-                            .filter(attribute -> attribute.getName().equals(incomingAttribute.getName()))
-                            .findFirst().orElse(null);
-                    if (existingPlayerAttribute != null) {
-                        return ImmutableAttribute.builder()
+                .map(incomingAttribute -> existingPlayer.getAttributes().stream()
+                        .filter(attribute -> attribute.getName().equals(incomingAttribute.getName()))
+                        .map(existingPlayerAttribute ->  ImmutableAttribute.builder()
                                 .from(existingPlayerAttribute)
                                 .name(incomingAttribute.getName())
                                 .value(incomingAttribute.getValue())
                                 .addHistory(incomingAttribute.getValue())
-                                .build();
-                    }
-                    // TODO: 1/2/2022 figure out if an error should be thrown if existing player attribute is null
-                    return incomingAttribute;
-                })
+                                .build()
+                        ).collect(Collectors.toList()))
+                .flatMap(Collection::stream)
                 .collect(Collectors.toList());
 
         Integer currentAbility = calculateCurrentAbility(updatedPlayerAttributes);

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/PlayerDataProvider.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/PlayerDataProvider.java
@@ -34,6 +34,8 @@ public class PlayerDataProvider {
      */
     public static final class PlayerBuilder {
         private boolean isExistingPlayer = false;
+        private boolean hasAttributeWithInvalidCategory = false;
+        private boolean hasAttributeWithInvalidGroup = false;
         private final ImmutablePlayer.Builder basePlayer = ImmutablePlayer.builder().clubId(UUID.randomUUID());
 
         private PlayerBuilder() { }
@@ -49,6 +51,16 @@ public class PlayerDataProvider {
 
         public PlayerBuilder isExistingPlayer(boolean isExisting) {
             this.isExistingPlayer = isExisting;
+            return this;
+        }
+
+        public PlayerBuilder hasAttributeWithInvalidCategory(boolean hasInvalidCategoryAttribute) {
+            this.hasAttributeWithInvalidCategory = hasInvalidCategoryAttribute;
+            return this;
+        }
+
+        public PlayerBuilder hasAttributeWithInvalidGroup(boolean hasInvalidGroupAttribute) {
+            this.hasAttributeWithInvalidGroup = hasInvalidGroupAttribute;
             return this;
         }
 
@@ -81,6 +93,60 @@ public class PlayerDataProvider {
             return this;
         }
 
+        public PlayerBuilder withTechnicalAttributes() {
+            String category = isExistingPlayer ? "Technical" : hasAttributeWithInvalidCategory ? "fake category" : null;
+            String group = isExistingPlayer ? "Attacking" : hasAttributeWithInvalidGroup ? "fake group" : null;
+
+            Attribute technicalAttribute = ImmutableAttribute.builder()
+                    .name("crossing")
+                    .value(CURRENT_PLAYER_CROSSING)
+                    .category(category)
+                    .group(group)
+                    .history(isExistingPlayer ? ImmutableList.of(CURRENT_PLAYER_CROSSING) : ImmutableList.of())
+                    .build();
+            basePlayer.addAttributes(technicalAttribute);
+            return this;
+        }
+
+        public PlayerBuilder withPhysicalAttributes() {
+            String category = isExistingPlayer ? "Physical" : hasAttributeWithInvalidCategory ? "fake category" : null;
+            String group = isExistingPlayer ? "Speed" : hasAttributeWithInvalidGroup ? "fake group" : null;
+
+            Attribute physicalAttribute = ImmutableAttribute.builder()
+                    .name("sprint speed")
+                    .value(CURRENT_PLAYER_SPRINT_SPEED)
+                    .category(category)
+                    .group(group)
+                    .history(isExistingPlayer ? ImmutableList.of(CURRENT_PLAYER_SPRINT_SPEED) : ImmutableList.of())
+                    .build();
+            basePlayer.addAttributes(physicalAttribute);
+            return this;
+        }
+
+        public PlayerBuilder withMentalAttributes() {
+            String category = isExistingPlayer ? "Mental" : hasAttributeWithInvalidCategory ? "fake category" : null;
+            String group = isExistingPlayer ? "Attacking" : hasAttributeWithInvalidGroup ? "fake group" : null;
+
+            Attribute mentalAttribute = ImmutableAttribute.builder()
+                    .name("composure")
+                    .value(CURRENT_PLAYER_COMPOSURE)
+                    .category(category)
+                    .group(group)
+                    .history(isExistingPlayer ? ImmutableList.of(CURRENT_PLAYER_COMPOSURE) : ImmutableList.of())
+                    .build();
+            basePlayer.addAttributes(mentalAttribute);
+            return this;
+        }
+
+        public PlayerBuilder withInvalidAttributes() {
+            Attribute invalidAttribute = ImmutableAttribute.builder()
+                    .name("fake attribute name")
+                    .value(Integer.valueOf("45"))
+                    .build();
+            basePlayer.addAttributes(invalidAttribute);
+            return this;
+        }
+
         public PlayerBuilder withAttributes() {
             Attribute technicalAttribute = ImmutableAttribute.builder()
                     .name("crossing")
@@ -105,7 +171,7 @@ public class PlayerDataProvider {
                     .group(isExistingPlayer ? "Attacking" : null)
                     .history(isExistingPlayer ? ImmutableList.of(CURRENT_PLAYER_COMPOSURE) : ImmutableList.of())
                     .build();
-            basePlayer.attributes(ImmutableList.of(technicalAttribute, physicalAttribute, mentalAttribute));
+            basePlayer.addAttributes(technicalAttribute, physicalAttribute, mentalAttribute);
             return this;
         }
 

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/PlayerResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/PlayerResourceTest.java
@@ -147,55 +147,6 @@ public class PlayerResourceTest {
     }
 
     /**
-     * given that the request contains a player entity without player roles, tests that no data is persisted and a 422
-     * response status is returned
-     */
-    @Test
-    public void createPlayerWhenPlayerRolesNotProvided() throws IOException {
-        // setup
-        Player incomingPlayer = PlayerDataProvider.PlayerBuilder.builder()
-                .isExistingPlayer(false)
-                .withMetadata()
-                .withAbility()
-                .withAttributes()
-                .build();
-
-        // execute
-        Response playerResponse = playerResource.createPlayer(userPrincipal, incomingPlayer, uriInfo);
-
-        // assert
-        verify(clubService, never()).getClub(any());
-        verify(playerService, never()).createPlayer(any(), any(), anyString());
-        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY_422, playerResponse.getStatus());
-        assertNotNull(playerResponse.getEntity());
-        assertEquals(incomingPlayer, playerResponse.getEntity());
-    }
-
-    /**
-     * given that the request contains a player entity without player attributes, tests that no data is persisted and a
-     * 422 response status is returned
-     */
-    @Test
-    public void createPlayerWhenPlayerAttributesNotProvided() throws IOException {
-        // setup
-        Player incomingPlayer = PlayerDataProvider.PlayerBuilder.builder()
-                .isExistingPlayer(false)
-                .withMetadata()
-                .withRoles()
-                .build();
-
-        // execute
-        Response playerResponse = playerResource.createPlayer(userPrincipal, incomingPlayer, uriInfo);
-
-        // assert
-        verify(clubService, never()).getClub(any());
-        verify(playerService, never()).createPlayer(any(), any(), anyString());
-        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY_422, playerResponse.getStatus());
-        assertNotNull(playerResponse.getEntity());
-        assertEquals(incomingPlayer, playerResponse.getEntity());
-    }
-
-    /**
      * given a valid player entity in the request, tests that the corresponding player data is updated
      */
     @Test

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/PlayerResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/PlayerResourceTest.java
@@ -7,6 +7,7 @@ import com.footballstatsdashboard.api.model.ImmutableUser;
 import com.footballstatsdashboard.api.model.Player;
 import com.footballstatsdashboard.api.model.User;
 import com.footballstatsdashboard.api.model.Club;
+import com.footballstatsdashboard.core.exceptions.ServiceException;
 import com.footballstatsdashboard.services.ClubService;
 import com.footballstatsdashboard.services.PlayerService;
 import io.dropwizard.jackson.Jackson;
@@ -25,7 +26,6 @@ import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -213,9 +213,9 @@ public class PlayerResourceTest {
 
     /**
      * given that the request contains a player entity whose ID does not match the existing player's ID, tests that
-     * the associated player data is not updated and a server error response is returned
+     * the associated player data is not updated and a service exception is thrown instead
      */
-    @Test
+    @Test(expected = ServiceException.class)
     public void updatePlayerWhenIncomingPlayerIdDoesNotMatchExisting() {
         // setup
         UUID existingPlayerId = UUID.randomUUID();
@@ -244,9 +244,6 @@ public class PlayerResourceTest {
         // assert
         verify(playerService).getPlayer(any());
         verify(playerService, never()).updatePlayer(any(), any(), any());
-
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR_500, playerResponse.getStatus());
-        assertTrue(playerResponse.getEntity().toString().contains(incomingPlayerId.toString()));
     }
 
     /**

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/services/PlayerServiceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/services/PlayerServiceTest.java
@@ -206,6 +206,34 @@ public class PlayerServiceTest {
     }
 
     /**
+     * given that the request contains a player entity without attributes of a particular category like TECHNICAL,
+     * tests that no data is persisted in couchbase and a service exception is thrown instead
+     */
+    @Test(expected = ServiceException.class)
+    public void createPlayerWhenTechnicalPlayerAttributesAreNotProvided() throws IOException {
+        // setup
+        Player incomingPlayer = PlayerDataProvider.PlayerBuilder.builder()
+                .isExistingPlayer(false)
+                .withMetadata()
+                .withAbility()
+                .withPhysicalAttributes()
+                .withMentalAttributes()
+                .withRoles()
+                .build();
+        Club existingClub = ClubDataProvider.ClubBuilder.builder()
+                .isExisting(true)
+                .existingUserId(UUID.randomUUID())
+                .withId(UUID.randomUUID())
+                .build();
+
+        // execute
+        playerService.createPlayer(incomingPlayer, existingClub, CREATED_BY);
+
+        // assert
+        verify(couchbaseDAO, never()).insertDocument(any(), any());
+    }
+
+    /**
      * given a valid player entity in the request, tests that an updated player entity with updated internal fields
      * is upserted in couchbase
      */

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/services/PlayerServiceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/services/PlayerServiceTest.java
@@ -8,6 +8,7 @@ import com.footballstatsdashboard.api.model.Player;
 import com.footballstatsdashboard.api.model.Club;
 import com.footballstatsdashboard.api.model.player.Attribute;
 import com.footballstatsdashboard.api.model.player.Metadata;
+import com.footballstatsdashboard.core.exceptions.ServiceException;
 import com.footballstatsdashboard.core.utils.FixtureLoader;
 import com.footballstatsdashboard.db.CouchbaseDAO;
 import com.footballstatsdashboard.db.key.ResourceKey;
@@ -29,6 +30,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -152,6 +154,58 @@ public class PlayerServiceTest {
     }
 
     /**
+     * given that the request contains a player entity without player roles, tests that no data is persisted in
+     * couchbase and a service exception is thrown instead
+     */
+    @Test(expected = ServiceException.class)
+    public void createPlayerWhenPlayerRolesAreNotProvided() throws IOException {
+        // setup
+        Player incomingPlayer = PlayerDataProvider.PlayerBuilder.builder()
+                .isExistingPlayer(false)
+                .withMetadata()
+                .withAbility()
+                .withAttributes()
+                .build();
+        Club existingClub = ClubDataProvider.ClubBuilder.builder()
+                .isExisting(true)
+                .existingUserId(UUID.randomUUID())
+                .withId(UUID.randomUUID())
+                .build();
+
+        // execute
+        playerService.createPlayer(incomingPlayer, existingClub, CREATED_BY);
+
+        // assert
+        verify(couchbaseDAO, never()).insertDocument(any(), any());
+    }
+
+    /**
+     * given that the request contains a player entity without player attributes, tests that no data is persisted in
+     * couchbase and a service exception is thrown instead
+     */
+    @Test(expected = ServiceException.class)
+    public void createPlayerWhenPlayerAttributesAreNotProvided() throws IOException {
+        // setup
+        Player incomingPlayer = PlayerDataProvider.PlayerBuilder.builder()
+                .isExistingPlayer(false)
+                .withMetadata()
+                .withAbility()
+                .withRoles()
+                .build();
+        Club existingClub = ClubDataProvider.ClubBuilder.builder()
+                .isExisting(true)
+                .existingUserId(UUID.randomUUID())
+                .withId(UUID.randomUUID())
+                .build();
+
+        // execute
+        playerService.createPlayer(incomingPlayer, existingClub, CREATED_BY);
+
+        // assert
+        verify(couchbaseDAO, never()).insertDocument(any(), any());
+    }
+
+    /**
      * given a valid player entity in the request, tests that an updated player entity with updated internal fields
      * is upserted in couchbase
      */
@@ -169,6 +223,8 @@ public class PlayerServiceTest {
                 .withRoles()
                 .withAttributes()
                 .build();
+        when(couchbaseDAO.getDocument(any(), any())).thenReturn(existingPlayerInCouchbase);
+
         Player incomingPlayerBase = PlayerDataProvider.PlayerBuilder.builder()
                 .isExistingPlayer(false)
                 .withId(existingPlayerId)
@@ -176,8 +232,6 @@ public class PlayerServiceTest {
                 .withRoles()
                 .withAttributes()
                 .build();
-        when(couchbaseDAO.getDocument(any(), any())).thenReturn(existingPlayerInCouchbase);
-
         Player incomingPlayer = PlayerDataProvider.ModifiedPlayerBuilder.builder()
                 .from(incomingPlayerBase)
                 .withUpdatedNameInMetadata("updated name")
@@ -216,6 +270,138 @@ public class PlayerServiceTest {
         // assertions for general house-keeping fields
         assertNotEquals(existingPlayerInCouchbase.getLastModifiedDate(), updatedPlayer.getLastModifiedDate());
         assertEquals(CREATED_BY, updatedPlayer.getCreatedBy());
+    }
+
+    /**
+     * given a player entity with attributes having invalid category and group information in the request, tests that
+     * the category and group names are derived from the existing data in couchbase instead of what is present in the
+     * request before updating the player data in couchbase
+     */
+    @Test
+    public void updatePlayerWithAttributesHavingInvalidCategoryAndGroupNames() {
+        // setup
+        ArgumentCaptor<ResourceKey> resourceKeyCaptor = ArgumentCaptor.forClass(ResourceKey.class);
+
+        UUID existingPlayerId = UUID.randomUUID();
+        Player existingPlayerInCouchbase = PlayerDataProvider.PlayerBuilder.builder()
+                .isExistingPlayer(true)
+                .withId(existingPlayerId)
+                .withMetadata()
+                .withAbility()
+                .withRoles()
+                .withAttributes()
+                .build();
+        when(couchbaseDAO.getDocument(any(), any())).thenReturn(existingPlayerInCouchbase);
+
+        Player incomingPlayerBase = PlayerDataProvider.PlayerBuilder.builder()
+                .isExistingPlayer(false)
+                .hasAttributeWithInvalidCategory(true)
+                .hasAttributeWithInvalidGroup(true)
+                .withId(existingPlayerId)
+                .withMetadata()
+                .withRoles()
+                .withTechnicalAttributes()
+                .withPhysicalAttributes()
+                .withMentalAttributes()
+                .build();
+        Player incomingPlayer = PlayerDataProvider.ModifiedPlayerBuilder.builder()
+                .from(incomingPlayerBase)
+                .withUpdatedNameInMetadata("updated name")
+                .withUpdatedRoleName("updated role name")
+                .withUpdatedAttributeValue("sprint speed", UPDATED_PLAYER_SPRINT_SPEED)
+                .build();
+
+        // execute
+        Player updatedPlayer = playerService.updatePlayer(incomingPlayer, existingPlayerInCouchbase, existingPlayerId);
+
+        // assert
+        verify(couchbaseDAO).updateDocument(resourceKeyCaptor.capture(), any());
+        ResourceKey capturedResourceKey = resourceKeyCaptor.getValue();
+        assertEquals(existingPlayerId, capturedResourceKey.getResourceId());
+
+        updatedPlayer.getAttributes().forEach(attribute -> {
+            Attribute existingPlayerAttribute = existingPlayerInCouchbase.getAttributes().stream()
+                    .filter(existingAttribute -> existingAttribute.getName().equals(attribute.getName()))
+                    .findFirst()
+                    .orElse(null);
+            assertNotNull(existingPlayerAttribute);
+            assertEquals(existingPlayerAttribute.getCategory(), attribute.getCategory());
+            assertEquals(existingPlayerAttribute.getGroup(), attribute.getGroup());
+        });
+    }
+
+    /**
+     * given a player entity without roles data in the request, tests that the corresponding player data in couchbase is
+     * not updated and a service exception is thrown instead
+     */
+    @Test(expected = ServiceException.class)
+    public void updatePlayerWhenPlayerRolesAreNotProvided() {
+        // setup
+        UUID existingPlayerId = UUID.randomUUID();
+        Player existingPlayerInCouchbase = PlayerDataProvider.PlayerBuilder.builder()
+                .isExistingPlayer(true)
+                .withId(existingPlayerId)
+                .withMetadata()
+                .withAbility()
+                .withRoles()
+                .withAttributes()
+                .build();
+        when(couchbaseDAO.getDocument(any(), any())).thenReturn(existingPlayerInCouchbase);
+
+        Player incomingPlayerBase = PlayerDataProvider.PlayerBuilder.builder()
+                .isExistingPlayer(false)
+                .withId(existingPlayerId)
+                .withMetadata()
+                .withAttributes()
+                .build();
+        Player incomingPlayer = PlayerDataProvider.ModifiedPlayerBuilder.builder()
+                .from(incomingPlayerBase)
+                .withUpdatedNameInMetadata("updated name")
+                .withUpdatedAttributeValue("sprint speed", UPDATED_PLAYER_SPRINT_SPEED)
+                .build();
+
+        // execute
+        playerService.updatePlayer(incomingPlayer, existingPlayerInCouchbase, existingPlayerId);
+
+        // assert
+        verify(couchbaseDAO, never()).updateDocument(any(), any());
+    }
+
+    /**
+     * given a player entity without attributes data in the request, tests that the corresponding player data in
+     * couchbase is not updated and a service exception is thrown instead
+     */
+    @Test(expected = ServiceException.class)
+    public void updatePlayerWhenPlayerAttributesAreNotProvided() {
+        // setup
+        UUID existingPlayerId = UUID.randomUUID();
+        Player existingPlayerInCouchbase = PlayerDataProvider.PlayerBuilder.builder()
+                .isExistingPlayer(true)
+                .withId(existingPlayerId)
+                .withMetadata()
+                .withAbility()
+                .withRoles()
+                .withAttributes()
+                .build();
+        when(couchbaseDAO.getDocument(any(), any())).thenReturn(existingPlayerInCouchbase);
+
+        Player incomingPlayerBase = PlayerDataProvider.PlayerBuilder.builder()
+                .isExistingPlayer(false)
+                .withId(existingPlayerId)
+                .withMetadata()
+                .withRoles()
+                .build();
+        Player incomingPlayer = PlayerDataProvider.ModifiedPlayerBuilder.builder()
+                .from(incomingPlayerBase)
+                .withUpdatedNameInMetadata("updated name")
+                .withUpdatedRoleName("updated role name")
+                .build();
+
+        // execute
+        playerService.updatePlayer(incomingPlayer, existingPlayerInCouchbase, existingPlayerId);
+
+        // assert
+        verify(couchbaseDAO, never()).updateDocument(any(), any());
     }
 
     /**


### PR DESCRIPTION
## Motivation and Context
This PR resolves #108. In this PR, added a custom exception class extending RuntimeException and registered a custom mapper for it in the application. Along with a new Validation entity, including a ValidationSeverity enum, this defines a streamlined behavior for handling erroneous behavior from a business logic point of view. The resource and service classes for the _Club_ and _Player_ entities have been updated to use this validation layer instead of ad-hoc handling of aforementioned erroneous behavior.

## How Has This Been Tested?
Largely speaking, existing tests have been updated to match the new expectations.
 
## Types of changes
<!--- What types of changes does the code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
