### PR TITLE
Handle scenarios with data access and existence

### DIFF
--- a/dashboard-server/src/main/java/com/footballstatsdashboard/db/CouchbaseDAO.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/db/CouchbaseDAO.java
@@ -44,14 +44,7 @@ public class CouchbaseDAO<K> {
 
     public <D> D getDocument(K key, Class<D> clazz) {
         String documentKey = this.keyProvider.getCouchbaseKey(key);
-        GetResult result;
-
-        try {
-            result = bucketContainer.getBucket().defaultCollection().get(documentKey);
-        } catch (DocumentNotFoundException docEx) {
-            throw new RuntimeException("Unable to find document with Id: " + documentKey);
-        }
-
+        GetResult result = bucketContainer.getBucket().defaultCollection().get(documentKey);
         return result.contentAs(clazz);
     }
 

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/db/CouchbaseDAO.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/db/CouchbaseDAO.java
@@ -1,6 +1,5 @@
 package com.footballstatsdashboard.db;
 
-import com.couchbase.client.core.error.DocumentNotFoundException;
 import com.couchbase.client.java.kv.GetResult;
 import com.footballstatsdashboard.client.couchbase.CouchbaseClientManager;
 import com.footballstatsdashboard.db.key.CouchbaseKeyProvider;
@@ -50,10 +49,6 @@ public class CouchbaseDAO<K> {
 
     public void deleteDocument(K key) {
         String documentKey = this.keyProvider.getCouchbaseKey(key);
-        try {
-            this.bucketContainer.getBucket().defaultCollection().remove(documentKey);
-        } catch (DocumentNotFoundException docEx) {
-            throw new RuntimeException("Unable to find document with Id: " + documentKey);
-        }
+        this.bucketContainer.getBucket().defaultCollection().remove(documentKey);
     }
 }

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/resources/ClubResource.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/resources/ClubResource.java
@@ -108,8 +108,7 @@ public class ClubResource {
             LOGGER.info("deleteClub() request for club with ID: {}", clubId);
         }
 
-        Club existingClub = this.clubService.getClub(clubId, user.getId());
-        this.clubService.deleteClub(clubId, existingClub, user.getId());
+        this.clubService.deleteClub(clubId, user.getId());
         return Response.noContent().build();
     }
 

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/resources/ClubResource.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/resources/ClubResource.java
@@ -46,13 +46,14 @@ public class ClubResource {
     @GET
     @Path(CLUB_ID_PATH)
     public Response getClub(
-            @Auth @PathParam(CLUB_ID) UUID clubId) {
+            @Auth User user,
+            @PathParam(CLUB_ID) UUID clubId) {
 
         if (LOGGER.isInfoEnabled()) {
             LOGGER.info("getClub() request for club with ID: {}", clubId);
         }
 
-        Club club = this.clubService.getClub(clubId);
+        Club club = this.clubService.getClub(clubId, user.getId());
         return Response.ok().entity(club).build();
     }
 
@@ -75,14 +76,15 @@ public class ClubResource {
     @PUT
     @Path(CLUB_ID_PATH)
     public Response updateClub(
-            @Auth @PathParam(CLUB_ID) UUID existingClubId,
+            @Auth User user,
+            @PathParam(CLUB_ID) UUID existingClubId,
             @Valid @NotNull Club incomingClub) {
 
         if (LOGGER.isInfoEnabled()) {
             LOGGER.info("updateClub() request for club with ID: {}", existingClubId);
         }
 
-        Club existingClub = this.clubService.getClub(existingClubId);
+        Club existingClub = this.clubService.getClub(existingClubId, user.getId());
         if (!existingClub.getId().equals(incomingClub.getId())) {
             String errorMessage = String.format(
                     "Incoming club entity ID: %s does not match ID of existing club entity %s.",

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/resources/ClubResource.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/resources/ClubResource.java
@@ -101,13 +101,15 @@ public class ClubResource {
     @DELETE
     @Path(CLUB_ID_PATH)
     public Response deleteClub(
-            @Auth @PathParam(CLUB_ID) UUID clubId) {
+            @Auth User user,
+            @PathParam(CLUB_ID) UUID clubId) {
 
         if (LOGGER.isInfoEnabled()) {
             LOGGER.info("deleteClub() request for club with ID: {}", clubId);
         }
 
-        this.clubService.deleteClub(clubId);
+        Club existingClub = this.clubService.getClub(clubId, user.getId());
+        this.clubService.deleteClub(clubId, existingClub, user.getId());
         return Response.noContent().build();
     }
 

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/resources/PlayerResource.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/resources/PlayerResource.java
@@ -69,7 +69,7 @@ public class PlayerResource {
         }
 
         // fetch details of club the incoming player belongs to
-        Club clubDataForNewPlayer = this.clubService.getClub(incomingPlayer.getClubId());
+        Club clubDataForNewPlayer = this.clubService.getClub(incomingPlayer.getClubId(), user.getId());
 
         Player newPlayer = this.playerService.createPlayer(incomingPlayer, clubDataForNewPlayer, user.getEmail());
 

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/resources/PlayerResource.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/resources/PlayerResource.java
@@ -27,6 +27,7 @@ import javax.ws.rs.core.UriInfo;
 import java.io.IOException;
 import java.net.URI;
 import java.util.UUID;
+import java.util.function.Predicate;
 
 import static com.footballstatsdashboard.core.utils.Constants.PLAYER_ID;
 import static com.footballstatsdashboard.core.utils.Constants.PLAYER_ID_PATH;
@@ -123,7 +124,8 @@ public class PlayerResource {
             LOGGER.info("deletePlayer() request for player with ID: {}", playerId);
         }
 
-        this.playerService.deletePlayer(playerId);
+        Predicate<UUID> doesClubBelongsToUser = clubId -> this.clubService.doesClubBelongToUser(clubId, user.getId());
+        this.playerService.deletePlayer(playerId, doesClubBelongsToUser);
         return Response.noContent().build();
     }
 }

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/resources/PlayerResource.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/resources/PlayerResource.java
@@ -116,7 +116,8 @@ public class PlayerResource {
     @DELETE
     @Path(PLAYER_ID_PATH)
     public Response deletePlayer(
-            @Auth @PathParam(PLAYER_ID) UUID playerId) {
+            @Auth User user,
+            @PathParam(PLAYER_ID) UUID playerId) {
 
         if (LOGGER.isInfoEnabled()) {
             LOGGER.info("deletePlayer() request for player with ID: {}", playerId);

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
@@ -136,9 +136,9 @@ public class ClubService {
         return updatedClub;
     }
 
-    public void deleteClub(UUID clubId, Club existingClub, UUID authorizedUserId) {
+    public void deleteClub(UUID clubId, UUID authorizedUserId) {
         // ensure user has access to the club that is being requested to be deleted
-        if (existingClub.getUserId() != authorizedUserId) {
+        if (!doesClubBelongToUser(clubId, authorizedUserId)) {
             LOGGER.error("Club with ID: {} does not belong to user making request (ID: {})",
                     clubId, authorizedUserId);
             throw new ServiceException(HttpStatus.FORBIDDEN_403, "User does not have access to this club!");

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
@@ -39,20 +39,23 @@ public class ClubService {
 
     public Club getClub(UUID clubId, UUID authorizedUserId) {
         ResourceKey resourceKey = new ResourceKey(clubId);
-
+        Club club;
         try {
-            Club club = this.clubDAO.getDocument(resourceKey, Club.class);
-            if (club.getUserId() != authorizedUserId) {
-                LOGGER.error("Club with ID: {} does not belong to user making request (ID: {})",
-                        clubId, authorizedUserId);
-                throw new ServiceException(HttpStatus.FORBIDDEN_403, "User does not have access to this club!");
-            }
-            return club;
+            club = this.clubDAO.getDocument(resourceKey, Club.class);
         } catch (DocumentNotFoundException documentNotFoundException) {
             String errorMessage = String.format("No club entity found for ID: %s", clubId);
             LOGGER.error(errorMessage);
             throw new ServiceException(HttpStatus.NOT_FOUND_404, errorMessage);
         }
+
+        // validate that the user has access to the club data being fetched
+        if (club.getUserId() != authorizedUserId) {
+            LOGGER.error("Club with ID: {} does not belong to user making request (ID: {})",
+                    clubId, authorizedUserId);
+            throw new ServiceException(HttpStatus.FORBIDDEN_403, "User does not have access to this club!");
+        }
+
+        return club;
     }
 
     public Club createClub(Club incomingClub, UUID userId, String createdBy) {

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
@@ -43,8 +43,8 @@ public class ClubService {
         try {
             return this.clubDAO.getDocument(resourceKey, Club.class);
         } catch (DocumentNotFoundException documentNotFoundException) {
-            String errorMessage = "No club entity found for ID: {}";
-            LOGGER.error(errorMessage, clubId);
+            String errorMessage = String.format("No club entity found for ID: %s", clubId);
+            LOGGER.error(errorMessage);
             throw new ServiceException(HttpStatus.NOT_FOUND_404, errorMessage);
         }
     }

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
@@ -45,8 +45,7 @@ public class ClubService {
             if (club.getUserId() != authorizedUserId) {
                 LOGGER.error("Club with ID: {} does not belong to user making request (ID: {})",
                         clubId, authorizedUserId);
-                throw new ServiceException(HttpStatus.UNPROCESSABLE_ENTITY_422,
-                        "User does not have access to this club!");
+                throw new ServiceException(HttpStatus.FORBIDDEN_403, "User does not have access to this club!");
             }
             return club;
         } catch (DocumentNotFoundException documentNotFoundException) {
@@ -141,8 +140,7 @@ public class ClubService {
         if (existingClub.getUserId() != authorizedUserId) {
             LOGGER.error("Club with ID: {} does not belong to user making request (ID: {})",
                     clubId, authorizedUserId);
-            throw new ServiceException(HttpStatus.FORBIDDEN_403,
-                    "User does not have access to this club!");
+            throw new ServiceException(HttpStatus.FORBIDDEN_403, "User does not have access to this club!");
         }
 
         ResourceKey resourceKey = new ResourceKey(clubId);

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
@@ -37,11 +37,18 @@ public class ClubService {
         this.clubDAO = clubDAO;
     }
 
-    public Club getClub(UUID clubId) {
+    public Club getClub(UUID clubId, UUID authorizedUserId) {
         ResourceKey resourceKey = new ResourceKey(clubId);
 
         try {
-            return this.clubDAO.getDocument(resourceKey, Club.class);
+            Club club = this.clubDAO.getDocument(resourceKey, Club.class);
+            if (club.getUserId() != authorizedUserId) {
+                LOGGER.error("Club with ID: {} does not belong to user making request (ID: {})",
+                        clubId, authorizedUserId);
+                throw new ServiceException(HttpStatus.UNPROCESSABLE_ENTITY_422,
+                        "User does not have access to this club!");
+            }
+            return club;
         } catch (DocumentNotFoundException documentNotFoundException) {
             String errorMessage = String.format("No club entity found for ID: %s", clubId);
             LOGGER.error(errorMessage);

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
@@ -47,7 +47,7 @@ public class ClubService {
         Club club = fetchClubData(clubId);
 
         // validate that the user has access to the club data being fetched
-        if (club.getUserId() != authorizedUserId) {
+        if (!authorizedUserId.equals(club.getUserId())) {
             LOGGER.error("Club with ID: {} does not belong to user making request (ID: {})",
                     clubId, authorizedUserId);
             throw new ServiceException(HttpStatus.FORBIDDEN_403, "User does not have access to this club!");

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
@@ -1,5 +1,6 @@
 package com.footballstatsdashboard.services;
 
+import com.couchbase.client.core.error.DocumentNotFoundException;
 import com.footballstatsdashboard.api.model.Club;
 import com.footballstatsdashboard.api.model.ImmutableClub;
 import com.footballstatsdashboard.api.model.club.ClubSummary;
@@ -38,7 +39,14 @@ public class ClubService {
 
     public Club getClub(UUID clubId) {
         ResourceKey resourceKey = new ResourceKey(clubId);
-        return this.clubDAO.getDocument(resourceKey, Club.class);
+
+        try {
+            return this.clubDAO.getDocument(resourceKey, Club.class);
+        } catch (DocumentNotFoundException documentNotFoundException) {
+            String errorMessage = "No club entity found for ID: {}";
+            LOGGER.error(errorMessage, clubId);
+            throw new ServiceException(HttpStatus.NOT_FOUND_404, errorMessage);
+        }
     }
 
     public Club createClub(Club incomingClub, UUID userId, String createdBy) {

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
@@ -131,7 +131,13 @@ public class ClubService {
 
     public void deleteClub(UUID clubId) {
         ResourceKey resourceKey = new ResourceKey(clubId);
-        this.clubDAO.deleteDocument(resourceKey);
+        try {
+            this.clubDAO.deleteDocument(resourceKey);
+        } catch (DocumentNotFoundException documentNotFoundException) {
+            LOGGER.error("No club entity found for ID: {}", clubId);
+            throw new ServiceException(HttpStatus.NOT_FOUND_404,
+                    String.format("Cannot delete club (ID: %s) that does not exist", clubId));
+        }
     }
 
     public List<ClubSummary> getClubSummariesByUserId(UUID userId) {

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
@@ -37,16 +37,14 @@ public class ClubService {
         this.clubDAO = clubDAO;
     }
 
+    // TODO: 1/22/2022 add some tests for this
+    public boolean doesClubBelongToUser(UUID clubId, UUID authorizedUserId) {
+        Club club = fetchClubData(clubId);
+        return authorizedUserId.equals(club.getUserId());
+    }
+
     public Club getClub(UUID clubId, UUID authorizedUserId) {
-        ResourceKey resourceKey = new ResourceKey(clubId);
-        Club club;
-        try {
-            club = this.clubDAO.getDocument(resourceKey, Club.class);
-        } catch (DocumentNotFoundException documentNotFoundException) {
-            String errorMessage = String.format("No club entity found for ID: %s", clubId);
-            LOGGER.error(errorMessage);
-            throw new ServiceException(HttpStatus.NOT_FOUND_404, errorMessage);
-        }
+        Club club = fetchClubData(clubId);
 
         // validate that the user has access to the club data being fetched
         if (club.getUserId() != authorizedUserId) {
@@ -162,6 +160,19 @@ public class ClubService {
 
     public List<SquadPlayer> getSquadPlayers(UUID clubId) {
         return this.clubDAO.getPlayersInClub(clubId);
+    }
+
+    private Club fetchClubData(UUID clubId) {
+        ResourceKey resourceKey = new ResourceKey(clubId);
+        Club club;
+        try {
+            club = this.clubDAO.getDocument(resourceKey, Club.class);
+        } catch (DocumentNotFoundException documentNotFoundException) {
+            String errorMessage = String.format("No club entity found for ID: %s", clubId);
+            LOGGER.error(errorMessage);
+            throw new ServiceException(HttpStatus.NOT_FOUND_404, errorMessage);
+        }
+        return club;
     }
 
     private List<Validation> validateIncomingClub(Club incomingClub, boolean isForNewClub) {

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
@@ -136,7 +136,15 @@ public class ClubService {
         return updatedClub;
     }
 
-    public void deleteClub(UUID clubId) {
+    public void deleteClub(UUID clubId, Club existingClub, UUID authorizedUserId) {
+        // ensure user has access to the club that is being requested to be deleted
+        if (existingClub.getUserId() != authorizedUserId) {
+            LOGGER.error("Club with ID: {} does not belong to user making request (ID: {})",
+                    clubId, authorizedUserId);
+            throw new ServiceException(HttpStatus.FORBIDDEN_403,
+                    "User does not have access to this club!");
+        }
+
         ResourceKey resourceKey = new ResourceKey(clubId);
         try {
             this.clubDAO.deleteDocument(resourceKey);

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/PlayerService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/PlayerService.java
@@ -44,17 +44,17 @@ public class PlayerService {
     private static final FixtureLoader FIXTURE_LOADER = new FixtureLoader(Jackson.newObjectMapper().copy());
     private static final Logger LOGGER = LoggerFactory.getLogger(PlayerService.class);
 
-    private final CouchbaseDAO<ResourceKey> couchbaseDAO;
+    private final CouchbaseDAO<ResourceKey> playerDAO;
 
-    public PlayerService(CouchbaseDAO<ResourceKey> couchbaseDAO) {
-        this.couchbaseDAO = couchbaseDAO;
+    public PlayerService(CouchbaseDAO<ResourceKey> playerDAO) {
+        this.playerDAO = playerDAO;
     }
 
     public Player getPlayer(UUID playerId) {
         ResourceKey resourceKey = new ResourceKey(playerId);
 
         try {
-            return this.couchbaseDAO.getDocument(resourceKey, Player.class);
+            return this.playerDAO.getDocument(resourceKey, Player.class);
         } catch (DocumentNotFoundException documentNotFoundException) {
             String errorMessage = String.format("No player entity found for ID: %s", playerId);
             LOGGER.error(errorMessage);
@@ -140,7 +140,7 @@ public class PlayerService {
                 .build();
 
         ResourceKey resourceKey = new ResourceKey(newPlayer.getId());
-        this.couchbaseDAO.insertDocument(resourceKey, newPlayer);
+        this.playerDAO.insertDocument(resourceKey, newPlayer);
 
         return newPlayer;
     }
@@ -185,7 +185,7 @@ public class PlayerService {
         Player updatedPlayer = updatedPlayerBuilder.build();
 
         ResourceKey resourceKey = new ResourceKey(playerId);
-        this.couchbaseDAO.updateDocument(resourceKey, updatedPlayer);
+        this.playerDAO.updateDocument(resourceKey, updatedPlayer);
         return updatedPlayer;
     }
 
@@ -193,7 +193,7 @@ public class PlayerService {
     public void deletePlayer(UUID playerId) {
         ResourceKey resourceKey = new ResourceKey(playerId);
         try {
-            this.couchbaseDAO.deleteDocument(resourceKey);
+            this.playerDAO.deleteDocument(resourceKey);
         } catch (DocumentNotFoundException documentNotFoundException) {
             LOGGER.error("No player entity found for ID: {}", playerId);
             throw new ServiceException(HttpStatus.NOT_FOUND_404,

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/PlayerService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/PlayerService.java
@@ -1,5 +1,6 @@
 package com.footballstatsdashboard.services;
 
+import com.couchbase.client.core.error.DocumentNotFoundException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.footballstatsdashboard.api.model.CountryCodeMetadata;
 import com.footballstatsdashboard.api.model.ImmutablePlayer;
@@ -51,7 +52,14 @@ public class PlayerService {
 
     public Player getPlayer(UUID playerId) {
         ResourceKey resourceKey = new ResourceKey(playerId);
-        return this.couchbaseDAO.getDocument(resourceKey, Player.class);
+
+        try {
+            return this.couchbaseDAO.getDocument(resourceKey, Player.class);
+        } catch (DocumentNotFoundException documentNotFoundException) {
+            String errorMessage = String.format("No player entity found for ID: %s", playerId);
+            LOGGER.error(errorMessage);
+            throw new ServiceException(HttpStatus.NOT_FOUND_404, errorMessage);
+        }
     }
 
     public Player createPlayer(Player incomingPlayer, Club clubDataForNewPlayer, String createdBy) throws IOException {

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/PlayerService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/PlayerService.java
@@ -192,7 +192,13 @@ public class PlayerService {
     // TODO: 1/3/2022 add checks to make sure player being deleted belongs to the club and user making the request
     public void deletePlayer(UUID playerId) {
         ResourceKey resourceKey = new ResourceKey(playerId);
-        this.couchbaseDAO.deleteDocument(resourceKey);
+        try {
+            this.couchbaseDAO.deleteDocument(resourceKey);
+        } catch (DocumentNotFoundException documentNotFoundException) {
+            LOGGER.error("No player entity found for ID: {}", playerId);
+            throw new ServiceException(HttpStatus.NOT_FOUND_404,
+                    String.format("Cannot delete player (ID: %s) that does not exist", playerId));
+        }
     }
 
     private List<Validation> validateIncomingPlayer(Player incomingPlayer, Player existingPlayer) {

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/ClubResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/ClubResourceTest.java
@@ -91,13 +91,13 @@ public class ClubResourceTest {
                 .withIncome()
                 .withExpenditure()
                 .build();
-        when(clubService.getClub(eq(clubId))).thenReturn(existingClub);
+        when(clubService.getClub(eq(clubId), any())).thenReturn(existingClub);
 
         // execute
-        Response clubResponse = clubResource.getClub(clubId);
+        Response clubResponse = clubResource.getClub(userPrincipal, clubId);
 
         // assert
-        verify(clubService).getClub(any());
+        verify(clubService).getClub(any(), any());
         assertEquals(HttpStatus.OK_200, clubResponse.getStatus());
         assertNotNull(clubResponse.getEntity());
 
@@ -156,7 +156,7 @@ public class ClubResourceTest {
                 .withIncome()
                 .withExpenditure()
                 .build();
-        when(clubService.getClub(any())).thenReturn(existingClub);
+        when(clubService.getClub(any(), any())).thenReturn(existingClub);
 
         BigDecimal updatedWageBudget = existingClub.getWageBudget().add(new BigDecimal("100"));
         BigDecimal updatedTransferBudget = existingClub.getTransferBudget().add(new BigDecimal("100"));
@@ -181,10 +181,10 @@ public class ClubResourceTest {
         when(clubService.updateClub(any(), any(), any())).thenReturn(updatedClub);
 
         // execute
-        Response clubResponse = clubResource.updateClub(existingClubId, incomingClub);
+        Response clubResponse = clubResource.updateClub(userPrincipal, existingClubId, incomingClub);
 
         // assert
-        verify(clubService).getClub(eq(existingClubId));
+        verify(clubService).getClub(eq(existingClubId), any());
         verify(clubService).updateClub(eq(incomingClub), eq(existingClub), eq(existingClubId));
 
         assertEquals(HttpStatus.OK_200, clubResponse.getStatus());
@@ -213,7 +213,7 @@ public class ClubResourceTest {
                 .withIncome()
                 .withExpenditure()
                 .build();
-        when(clubService.getClub(any())).thenReturn(existingClub);
+        when(clubService.getClub(any(), any())).thenReturn(existingClub);
 
         UUID incorrectIncomingClubId = UUID.randomUUID();
         Club incomingClub = ClubDataProvider.ClubBuilder.builder()
@@ -222,10 +222,10 @@ public class ClubResourceTest {
                 .build();
 
         // execute
-        clubResource.updateClub(existingClubId, incomingClub);
+        clubResource.updateClub(userPrincipal, existingClubId, incomingClub);
 
         // assert
-        verify(clubService).getClub(any());
+        verify(clubService).getClub(any(), any());
         verify(clubService, never()).updateClub(any(), any(), any());
     }
 

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/ClubResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/ClubResourceTest.java
@@ -273,36 +273,13 @@ public class ClubResourceTest {
     public void deleteClubRemovesClubData() {
         // setup
         UUID clubId = UUID.randomUUID();
-        Club existingClub = ClubDataProvider.ClubBuilder.builder()
-                .isExisting(true)
-                .withId(clubId)
-                .existingUserId(UUID.randomUUID())
-                .build();
-        when(clubService.getClub(eq(clubId), eq(userPrincipal.getId()))).thenReturn(existingClub);
 
         // execute
         Response clubResponse = clubResource.deleteClub(userPrincipal, clubId);
 
         // assert
-        verify(clubService).getClub(any(), any());
-        verify(clubService).deleteClub(any(), any(), any());
+        verify(clubService).deleteClub(any(), any());
         assertEquals(HttpStatus.NO_CONTENT_204, clubResponse.getStatus());
-    }
-
-    /**
-     * given an invalid club id, tests that no data is deleted and a service exception is thrown instead
-     */
-    @Test(expected = ServiceException.class)
-    public void deleteClubWhenClubDataDoesNotExist() {
-        // setup
-        UUID invalidClubId = UUID.randomUUID();
-        when(clubService.getClub(eq(invalidClubId), eq(userPrincipal.getId()))).thenThrow(ServiceException.class);
-
-        // execute
-        clubResource.deleteClub(userPrincipal, invalidClubId);
-
-        // assert
-        verify(clubService, never()).deleteClub(any(), any(), any());
     }
 
     /**

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/ClubResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/ClubResourceTest.java
@@ -107,8 +107,6 @@ public class ClubResourceTest {
         assertEquals(userPrincipal.getId(), clubFromResponse.getUserId());
     }
 
-    // TODO: 1/3/2022 test that the runtime exception thrown when a couchbase document is not found results in a 404
-
     /**
      * given a valid club entity in the request, tests that the club data is successfully persisted
      */
@@ -295,7 +293,7 @@ public class ClubResourceTest {
      * given an invalid club id, tests that no data is deleted and a service exception is thrown instead
      */
     @Test(expected = ServiceException.class)
-    public void deleteClubWhenClubNotFoundInCouchbase() {
+    public void deleteClubWhenClubDataDoesNotExist() {
         // setup
         UUID invalidClubId = UUID.randomUUID();
         when(clubService.getClub(eq(invalidClubId), eq(userPrincipal.getId()))).thenThrow(ServiceException.class);

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/PlayerResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/PlayerResourceTest.java
@@ -389,7 +389,7 @@ public class PlayerResourceTest {
     }
 
     /**
-     * given a valid player id, removes the player data and a 204 No Content response is returned
+     * given a valid player id, tests that the player data is removed and a 204 No Content response is returned
      */
     @Test
     public void deletePlayerRemovesPlayerData() {
@@ -397,7 +397,7 @@ public class PlayerResourceTest {
         UUID playerId = UUID.randomUUID();
 
         // execute
-        Response playerResponse = playerResource.deletePlayer(playerId);
+        Response playerResponse = playerResource.deletePlayer(userPrincipal, playerId);
 
         // assert
         verify(playerService).deletePlayer(eq(playerId));

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/PlayerResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/PlayerResourceTest.java
@@ -132,7 +132,7 @@ public class PlayerResourceTest {
                 .existingUserId(userPrincipal.getId())
                 .withId(UUID.randomUUID())
                 .build();
-        when(clubService.getClub(any())).thenReturn(existingClub);
+        when(clubService.getClub(any(), any())).thenReturn(existingClub);
 
         // execute
         Response playerResponse = playerResource.createPlayer(userPrincipal, incomingPlayer, uriInfo);

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/PlayerResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/PlayerResourceTest.java
@@ -400,9 +400,7 @@ public class PlayerResourceTest {
         Response playerResponse = playerResource.deletePlayer(userPrincipal, playerId);
 
         // assert
-        verify(playerService).deletePlayer(eq(playerId));
+        verify(playerService).deletePlayer(eq(playerId), any());
         assertEquals(HttpStatus.NO_CONTENT_204, playerResponse.getStatus());
     }
-
-    // TODO: 1/6/2022 add test when trying to delete a player from a club not belonging to user
 }

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/PlayerResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/PlayerResourceTest.java
@@ -81,7 +81,7 @@ public class PlayerResourceTest {
     public void getPlayerSuccessfullyFetchesPlayerData() {
         // setup
         UUID playerId = UUID.randomUUID();
-        Player playerFromCouchbase = PlayerDataProvider.PlayerBuilder.builder()
+        Player playerToBeFetched = PlayerDataProvider.PlayerBuilder.builder()
                 .isExistingPlayer(true)
                 .withId(playerId)
                 .withMetadata()
@@ -89,7 +89,7 @@ public class PlayerResourceTest {
                 .withRoles()
                 .withAttributes()
                 .build();
-        when(playerService.getPlayer(eq(playerId))).thenReturn(playerFromCouchbase);
+        when(playerService.getPlayer(eq(playerId))).thenReturn(playerToBeFetched);
 
         // execute
         Response playerResponse = playerResource.getPlayer(playerId);

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/services/ClubServiceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/services/ClubServiceTest.java
@@ -505,12 +505,14 @@ public class ClubServiceTest {
                 .withIncome()
                 .withExpenditure()
                 .build();
+        when(clubDAO.getDocument(any(), any())).thenReturn(existingClub);
         ArgumentCaptor<ResourceKey> resourceKeyCaptor = ArgumentCaptor.forClass(ResourceKey.class);
 
         // execute
-        clubService.deleteClub(clubId, existingClub, userId);
+        clubService.deleteClub(clubId, userId);
 
         // assert
+        verify(clubDAO).getDocument(any(), any());
         verify(clubDAO).deleteDocument(resourceKeyCaptor.capture());
         ResourceKey capturedResourceKey = resourceKeyCaptor.getValue();
         assertEquals(clubId, capturedResourceKey.getResourceId());
@@ -531,14 +533,31 @@ public class ClubServiceTest {
                 .withIncome()
                 .withExpenditure()
                 .build();
+        when(clubDAO.getDocument(any(), any())).thenReturn(existingClub);
 
         // execute
-        clubService.deleteClub(existingClubId, existingClub, userId);
+        clubService.deleteClub(existingClubId, userId);
+
+        // assert
+        verify(clubDAO).getDocument(any(), any());
+        verify(clubDAO, never()).deleteDocument(any());
+    }
+
+    /**
+     * given an invalid club id, tests that no data is deleted and a service exception is thrown instead
+     */
+    @Test(expected = ServiceException.class)
+    public void deleteClubWhenClubDataDoesNotExist() {
+        // setup
+        UUID invalidClubId = UUID.randomUUID();
+        when(clubDAO.getDocument(any(), any())).thenThrow(DocumentNotFoundException.class);
+
+        // execute
+        clubService.deleteClub(invalidClubId, userId);
 
         // assert
         verify(clubDAO, never()).deleteDocument(any());
     }
-
     /**
      * given a valid user entity as the auth principal, tests that all clubs associated with the user is fetched from
      * couchbase

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/services/ClubServiceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/services/ClubServiceTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -483,6 +484,25 @@ public class ClubServiceTest {
         verify(clubDAO).deleteDocument(resourceKeyCaptor.capture());
         ResourceKey capturedResourceKey = resourceKeyCaptor.getValue();
         assertEquals(clubId, capturedResourceKey.getResourceId());
+    }
+
+    /**
+     * given an invalid club id, tests that the DocumentNotFound exception thrown by the DAO layer is handled and a
+     * ServiceException is thrown instead
+     */
+    @Test(expected = ServiceException.class)
+    public void deleteClubWhenClubNotFoundInCouchbase() {
+        // setup
+        UUID invalidClubId = UUID.randomUUID();
+        ArgumentCaptor<ResourceKey> resourceKeyCaptor = ArgumentCaptor.forClass(ResourceKey.class);
+        doThrow(DocumentNotFoundException.class).when(clubDAO).deleteDocument(any());
+
+        // execute
+        clubService.deleteClub(invalidClubId);
+
+        // assert
+        verify(clubDAO).deleteDocument(resourceKeyCaptor.capture());
+        assertEquals(invalidClubId, resourceKeyCaptor.getValue().getResourceId());
     }
 
     /**

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/services/ClubServiceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/services/ClubServiceTest.java
@@ -1,5 +1,6 @@
 package com.footballstatsdashboard.services;
 
+import com.couchbase.client.core.error.DocumentNotFoundException;
 import com.footballstatsdashboard.ClubDataProvider;
 import com.footballstatsdashboard.api.model.Club;
 import com.footballstatsdashboard.api.model.club.ClubSummary;
@@ -82,17 +83,15 @@ public class ClubServiceTest {
         assertEquals(userId, club.getUserId());
     }
 
-    // TODO: 1/15/2022 verify that a 404 is thrown here instead of a raw runtime exception
     /**
-     * given a runtime exception is thrown by couchbase DAO when club entity is not found, verifies that the same
-     * exception is thrown by `getClub` resource method as well
+     * given an invalid club id, tests that the DocumentNotFound exception thrown by the DAO layer is handled and a
+     * ServiceException is thrown instead
      */
-    @Test(expected = RuntimeException.class)
+    @Test(expected = ServiceException.class)
     public void getClubWhenClubNotFoundInCouchbase() {
         // setup
         UUID invalidClubId = UUID.randomUUID();
-        when(clubDAO.getDocument(any(), any()))
-                .thenThrow(new RuntimeException("Unable to find document with ID: " + invalidClubId));
+        when(clubDAO.getDocument(any(), any())).thenThrow(DocumentNotFoundException.class);
 
         // execute
         clubService.getClub(invalidClubId);

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/services/ClubServiceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/services/ClubServiceTest.java
@@ -72,7 +72,7 @@ public class ClubServiceTest {
         when(clubDAO.getDocument(any(), any())).thenReturn(clubFromCouchbase);
 
         // execute
-        Club club = clubService.getClub(clubId);
+        Club club = clubService.getClub(clubId, userId);
 
         // assert
         verify(clubDAO).getDocument(any(), any());
@@ -95,7 +95,31 @@ public class ClubServiceTest {
         when(clubDAO.getDocument(any(), any())).thenThrow(DocumentNotFoundException.class);
 
         // execute
-        clubService.getClub(invalidClubId);
+        clubService.getClub(invalidClubId, userId);
+
+        // assert
+        verify(clubDAO).getDocument(any(), any());
+    }
+
+    /**
+     * given a club id for a club the user does not have access to, tests that the club data is not returned and a
+     * service exception is thrown instead
+     */
+    @Test(expected = ServiceException.class)
+    public void getClubWhenClubDoesNotBelongToUser() {
+        // setup
+        UUID clubId = UUID.randomUUID();
+        Club clubFromCouchbase = ClubDataProvider.ClubBuilder.builder()
+                .isExisting(true)
+                .existingUserId(UUID.randomUUID())
+                .withId(clubId)
+                .withIncome()
+                .withExpenditure()
+                .build();
+        when(clubDAO.getDocument(any(), any())).thenReturn(clubFromCouchbase);
+
+        // execute
+        clubService.getClub(clubId, userId);
 
         // assert
         verify(clubDAO).getDocument(any(), any());

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/services/PlayerServiceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/services/PlayerServiceTest.java
@@ -1,5 +1,6 @@
 package com.footballstatsdashboard.services;
 
+import com.couchbase.client.core.error.DocumentNotFoundException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.footballstatsdashboard.ClubDataProvider;
 import com.footballstatsdashboard.PlayerDataProvider;
@@ -83,15 +84,14 @@ public class PlayerServiceTest {
     }
 
     /**
-     * given a runtime exception is thrown by couchbase DAO when player entity is not found, verifies that the same
-     * exception is thrown by `getPlayer` resource method as well
+     * given an invalid player id, tests that the DocumentNotFound exception thrown by the DAO layer is handled and a
+     * ServiceException is thrown instead
      */
-    @Test(expected = RuntimeException.class)
+    @Test(expected = ServiceException.class)
     public void getPlayerWhenPlayerNotFoundInCouchbase() {
         // setup
         UUID invalidPlayerId = UUID.randomUUID();
-        when(couchbaseDAO.getDocument(any(), any()))
-                .thenThrow(new RuntimeException("Unable to find document with Id: " + invalidPlayerId));
+        when(couchbaseDAO.getDocument(any(), any())).thenThrow(DocumentNotFoundException.class);
 
         // execute
         playerService.getPlayer(invalidPlayerId);

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/services/PlayerServiceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/services/PlayerServiceTest.java
@@ -489,22 +489,22 @@ public class PlayerServiceTest {
     }
 
     /**
-     * given that the couchbase DAO throws a RuntimeException when it cannot find the player entity to remove, the
-     * same exception is propagated and thrown by the resource method as well
+     * given an invalid player id, tests that the DocumentNotFound exception thrown by the DAO layer is handled and a
+     * ServiceException is thrown instead
      */
-    @Test(expected = RuntimeException.class)
+    @Test(expected = ServiceException.class)
     public void deletePlayerWhenPlayerNotFound() {
         // setup
-        UUID playerId = UUID.randomUUID();
+        UUID invalidPlayerId = UUID.randomUUID();
         ArgumentCaptor<ResourceKey> resourceKeyCaptor = ArgumentCaptor.forClass(ResourceKey.class);
-        doThrow(new RuntimeException("player not found")).when(couchbaseDAO).deleteDocument(any());
+        doThrow(ServiceException.class).when(couchbaseDAO).deleteDocument(any());
 
         // execute
-        playerService.deletePlayer(playerId);
+        playerService.deletePlayer(invalidPlayerId);
 
         // assert
         verify(couchbaseDAO).deleteDocument(resourceKeyCaptor.capture());
-        assertEquals(playerId, resourceKeyCaptor.getValue().getResourceId());
+        assertEquals(invalidPlayerId, resourceKeyCaptor.getValue().getResourceId());
     }
 
     private void assertCountryLogo(Metadata createdPlayerMetadata) throws IOException {

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/services/PlayerServiceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/services/PlayerServiceTest.java
@@ -46,7 +46,7 @@ public class PlayerServiceTest {
     private PlayerService playerService;
 
     @Mock
-    private CouchbaseDAO<ResourceKey> couchbaseDAO;
+    private CouchbaseDAO<ResourceKey> playerDAO;
 
     /**
      * set up test data before each test case is run
@@ -54,7 +54,7 @@ public class PlayerServiceTest {
     @Before
     public void initialize() {
         MockitoAnnotations.openMocks(this);
-        playerService = new PlayerService(couchbaseDAO);
+        playerService = new PlayerService(playerDAO);
     }
 
     /**
@@ -73,13 +73,13 @@ public class PlayerServiceTest {
                 .withRoles()
                 .withAttributes()
                 .build();
-        when(couchbaseDAO.getDocument(any(), any())).thenReturn(playerFromCouchbase);
+        when(playerDAO.getDocument(any(), any())).thenReturn(playerFromCouchbase);
 
         // execute
         Player player = playerService.getPlayer(playerId);
 
         // assert
-        verify(couchbaseDAO).getDocument(any(), any());
+        verify(playerDAO).getDocument(any(), any());
         assertEquals(playerId, player.getId());
     }
 
@@ -91,13 +91,13 @@ public class PlayerServiceTest {
     public void getPlayerWhenPlayerNotFoundInCouchbase() {
         // setup
         UUID invalidPlayerId = UUID.randomUUID();
-        when(couchbaseDAO.getDocument(any(), any())).thenThrow(DocumentNotFoundException.class);
+        when(playerDAO.getDocument(any(), any())).thenThrow(DocumentNotFoundException.class);
 
         // execute
         playerService.getPlayer(invalidPlayerId);
 
         // assert
-        verify(couchbaseDAO).getDocument(any(), any());
+        verify(playerDAO).getDocument(any(), any());
     }
 
     /**
@@ -125,7 +125,7 @@ public class PlayerServiceTest {
         Player createdPlayer = playerService.createPlayer(incomingPlayer, existingClub, CREATED_BY);
 
         // assert
-        verify(couchbaseDAO).insertDocument(any(), newPlayerCaptor.capture());
+        verify(playerDAO).insertDocument(any(), newPlayerCaptor.capture());
         Player newPlayer = newPlayerCaptor.getValue();
         assertEquals(createdPlayer, newPlayer);
 
@@ -176,7 +176,7 @@ public class PlayerServiceTest {
         playerService.createPlayer(incomingPlayer, existingClub, CREATED_BY);
 
         // assert
-        verify(couchbaseDAO, never()).insertDocument(any(), any());
+        verify(playerDAO, never()).insertDocument(any(), any());
     }
 
     /**
@@ -202,7 +202,7 @@ public class PlayerServiceTest {
         playerService.createPlayer(incomingPlayer, existingClub, CREATED_BY);
 
         // assert
-        verify(couchbaseDAO, never()).insertDocument(any(), any());
+        verify(playerDAO, never()).insertDocument(any(), any());
     }
 
     /**
@@ -230,7 +230,7 @@ public class PlayerServiceTest {
         playerService.createPlayer(incomingPlayer, existingClub, CREATED_BY);
 
         // assert
-        verify(couchbaseDAO, never()).insertDocument(any(), any());
+        verify(playerDAO, never()).insertDocument(any(), any());
     }
 
     /**
@@ -251,7 +251,7 @@ public class PlayerServiceTest {
                 .withRoles()
                 .withAttributes()
                 .build();
-        when(couchbaseDAO.getDocument(any(), any())).thenReturn(existingPlayerInCouchbase);
+        when(playerDAO.getDocument(any(), any())).thenReturn(existingPlayerInCouchbase);
 
         Player incomingPlayerBase = PlayerDataProvider.PlayerBuilder.builder()
                 .isExistingPlayer(false)
@@ -271,7 +271,7 @@ public class PlayerServiceTest {
         Player updatedPlayer = playerService.updatePlayer(incomingPlayer, existingPlayerInCouchbase, existingPlayerId);
 
         // assert
-        verify(couchbaseDAO).updateDocument(resourceKeyCaptor.capture(), any());
+        verify(playerDAO).updateDocument(resourceKeyCaptor.capture(), any());
         ResourceKey capturedResourceKey = resourceKeyCaptor.getValue();
         assertEquals(existingPlayerId, capturedResourceKey.getResourceId());
 
@@ -319,7 +319,7 @@ public class PlayerServiceTest {
                 .withRoles()
                 .withAttributes()
                 .build();
-        when(couchbaseDAO.getDocument(any(), any())).thenReturn(existingPlayerInCouchbase);
+        when(playerDAO.getDocument(any(), any())).thenReturn(existingPlayerInCouchbase);
 
         Player incomingPlayerBase = PlayerDataProvider.PlayerBuilder.builder()
                 .isExistingPlayer(false)
@@ -343,7 +343,7 @@ public class PlayerServiceTest {
         Player updatedPlayer = playerService.updatePlayer(incomingPlayer, existingPlayerInCouchbase, existingPlayerId);
 
         // assert
-        verify(couchbaseDAO).updateDocument(resourceKeyCaptor.capture(), any());
+        verify(playerDAO).updateDocument(resourceKeyCaptor.capture(), any());
         ResourceKey capturedResourceKey = resourceKeyCaptor.getValue();
         assertEquals(existingPlayerId, capturedResourceKey.getResourceId());
 
@@ -374,7 +374,7 @@ public class PlayerServiceTest {
                 .withRoles()
                 .withAttributes()
                 .build();
-        when(couchbaseDAO.getDocument(any(), any())).thenReturn(existingPlayerInCouchbase);
+        when(playerDAO.getDocument(any(), any())).thenReturn(existingPlayerInCouchbase);
 
         Player incomingPlayerBase = PlayerDataProvider.PlayerBuilder.builder()
                 .isExistingPlayer(false)
@@ -392,7 +392,7 @@ public class PlayerServiceTest {
         playerService.updatePlayer(incomingPlayer, existingPlayerInCouchbase, existingPlayerId);
 
         // assert
-        verify(couchbaseDAO, never()).updateDocument(any(), any());
+        verify(playerDAO, never()).updateDocument(any(), any());
     }
 
     /**
@@ -411,7 +411,7 @@ public class PlayerServiceTest {
                 .withRoles()
                 .withAttributes()
                 .build();
-        when(couchbaseDAO.getDocument(any(), any())).thenReturn(existingPlayerInCouchbase);
+        when(playerDAO.getDocument(any(), any())).thenReturn(existingPlayerInCouchbase);
 
         Player incomingPlayerBase = PlayerDataProvider.PlayerBuilder.builder()
                 .isExistingPlayer(false)
@@ -429,7 +429,7 @@ public class PlayerServiceTest {
         playerService.updatePlayer(incomingPlayer, existingPlayerInCouchbase, existingPlayerId);
 
         // assert
-        verify(couchbaseDAO, never()).updateDocument(any(), any());
+        verify(playerDAO, never()).updateDocument(any(), any());
     }
 
     /**
@@ -448,7 +448,7 @@ public class PlayerServiceTest {
                 .withRoles()
                 .withAttributes()
                 .build();
-        when(couchbaseDAO.getDocument(any(), any())).thenReturn(existingPlayerInCouchbase);
+        when(playerDAO.getDocument(any(), any())).thenReturn(existingPlayerInCouchbase);
 
         Player incomingPlayerBase = PlayerDataProvider.PlayerBuilder.builder()
                 .isExistingPlayer(false)
@@ -468,7 +468,7 @@ public class PlayerServiceTest {
         playerService.updatePlayer(incomingPlayer, existingPlayerInCouchbase, existingPlayerId);
 
         // assert
-        verify(couchbaseDAO, never()).updateDocument(any(), any());
+        verify(playerDAO, never()).updateDocument(any(), any());
     }
 
     /**
@@ -484,7 +484,7 @@ public class PlayerServiceTest {
         playerService.deletePlayer(playerId);
 
         // assert
-        verify(couchbaseDAO).deleteDocument(resourceKeyCaptor.capture());
+        verify(playerDAO).deleteDocument(resourceKeyCaptor.capture());
         assertEquals(playerId, resourceKeyCaptor.getValue().getResourceId());
     }
 
@@ -497,13 +497,13 @@ public class PlayerServiceTest {
         // setup
         UUID invalidPlayerId = UUID.randomUUID();
         ArgumentCaptor<ResourceKey> resourceKeyCaptor = ArgumentCaptor.forClass(ResourceKey.class);
-        doThrow(ServiceException.class).when(couchbaseDAO).deleteDocument(any());
+        doThrow(ServiceException.class).when(playerDAO).deleteDocument(any());
 
         // execute
         playerService.deletePlayer(invalidPlayerId);
 
         // assert
-        verify(couchbaseDAO).deleteDocument(resourceKeyCaptor.capture());
+        verify(playerDAO).deleteDocument(resourceKeyCaptor.capture());
         assertEquals(invalidPlayerId, resourceKeyCaptor.getValue().getResourceId());
     }
 


### PR DESCRIPTION
## Motivation and Context
This PR resolves #107 and #109. In the PR, added functionality to gracefully handle _DocumentNotFoundException_ thrown by the DAO layer when a document being fetched does not exist. Additionally, added some business logic to handle scenarios where the user does not have access to create/update/delete the resource in question.

## How Has This Been Tested?
Added tests for the following scenarios:
* Club being fetched does not exist
* Club being fetched is not accessible to the user
* Club being updated does not exist
* Club being updated is not accessible to the user
* Club being deleted does not exist
* Club being deleted is not accessible to the user.

Similar cases for the player resource were added as well.

## Types of changes
<!--- What types of changes does the code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
