### PR TITLE
Fix redirection issues in client code

### DIFF
--- a/dashboard-ui/src/Layout.js
+++ b/dashboard-ui/src/Layout.js
@@ -6,12 +6,11 @@ import CssBaseline from '@material-ui/core/CssBaseline';
 import { makeStyles } from '@material-ui/core/styles';
 
 import AppBarMenu from './components/AppBarMenu';
-import StyledLoadingCircle from './components/StyledLoadingCircle';
 import Sidebar from './widgets/Sidebar';
 import UserAuth from './pages/UserAuth';
 import routingData from './routing/routingData';
-import useUserData from './hooks/useUserData';
 import PrivateRoute from './routing/PrivateRoute';
+import { useUserAuth } from './context/authProvider';
 
 const useStyles = makeStyles(theme => ({
     root: {
@@ -96,18 +95,12 @@ AppContainer.propTypes = {
 export default function Layout() {
     const classes = useStyles();
 
-    const { isLoading, isLoggedIn } = useUserData();
+    const { isUserLoggedIn } = useUserAuth();
 
     return (
         <div className={classes.root}>
             <CssBaseline />
-            {isLoading ? (
-                <StyledLoadingCircle />
-            ) : isLoggedIn ? (
-                <AppContainer classes={classes} />
-            ) : (
-                <UserAuth classes={classes} />
-            )}
+            {isUserLoggedIn() ? <AppContainer classes={classes} /> : <UserAuth classes={classes} />}
         </div>
     );
 }

--- a/dashboard-ui/src/Layout.js
+++ b/dashboard-ui/src/Layout.js
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Link, Route, Switch } from 'react-router-dom';
+import { Link, Redirect, Route, Switch } from 'react-router-dom';
 
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { makeStyles } from '@material-ui/core/styles';
@@ -10,7 +10,6 @@ import Sidebar from './widgets/Sidebar';
 import UserAuth from './pages/UserAuth';
 import routingData from './routing/routingData';
 import PrivateRoute from './routing/PrivateRoute';
-import { useUserAuth } from './context/authProvider';
 
 const useStyles = makeStyles(theme => ({
     root: {
@@ -69,18 +68,15 @@ const AppContainer = ({ classes }) => {
             <main className={classes.content}>
                 <div className={classes.view}>
                     <Switch>
-                        {routingData.map((sidebarItemData, _idx) => {
-                            return sidebarItemData.disabledPaths ? (
-                                <PrivateRoute path={sidebarItemData.routePath} component={sidebarItemData.component} />
-                            ) : (
-                                <Route
-                                    exact={sidebarItemData.isExact}
-                                    key={_idx}
-                                    path={sidebarItemData.routePath}
-                                    component={sidebarItemData.component}
-                                />
-                            );
-                        })}
+                        {routingData.map((sidebarItemData, idx) => (
+                            <PrivateRoute
+                                key={idx}
+                                exact={sidebarItemData.isExact}
+                                path={sidebarItemData.routePath}
+                                component={sidebarItemData.component}
+                            />
+                        ))}
+                        <Redirect to='/' />
                     </Switch>
                 </div>
             </main>
@@ -95,12 +91,15 @@ AppContainer.propTypes = {
 export default function Layout() {
     const classes = useStyles();
 
-    const { isUserLoggedIn } = useUserAuth();
-
     return (
         <div className={classes.root}>
             <CssBaseline />
-            {isUserLoggedIn() ? <AppContainer classes={classes} /> : <UserAuth classes={classes} />}
+            <Switch>
+                <Route path='/auth'>
+                    <UserAuth classes={classes} />
+                </Route>
+                <PrivateRoute path='/' component={AppContainer} componentProps={{ classes }}/>
+            </Switch>
         </div>
     );
 }

--- a/dashboard-ui/src/components/SignIn.js
+++ b/dashboard-ui/src/components/SignIn.js
@@ -123,7 +123,7 @@ export default function SignIn({ values, handleChange, handleSubmit, validations
                         </Link>
                     </Grid> */}
                     <Grid item>
-                        <Link to='/signUp' component={RouterLink} variant='body2'>
+                        <Link to='/auth/signUp' component={RouterLink} variant='body2'>
                             Don&apos;t have an account? Sign Up
                         </Link>
                     </Grid>

--- a/dashboard-ui/src/components/Signup.js
+++ b/dashboard-ui/src/components/Signup.js
@@ -157,7 +157,7 @@ export default function Signup({ values, handleChange, handleSubmit, validations
                 </Button>
                 <Grid container justifyContent='flex-end'>
                     <Grid item>
-                        <Link to='/' component={RouterLink} variant='body2'>
+                        <Link to='/auth/signIn' component={RouterLink} variant='body2'>
                             Already have an account? Sign In
                         </Link>
                     </Grid>

--- a/dashboard-ui/src/context/authProvider.js
+++ b/dashboard-ui/src/context/authProvider.js
@@ -14,6 +14,8 @@ function AuthContextProvider({ children }) {
     const [authData, setAuthData] = useState(existingAuthData);
     const queryClient = useQueryClient();
 
+    const isUserLoggedIn = () => !!authData;
+
     const login = async ({ email, password }, setAuthData) => {
         let authData;
         let errorMessage = null;
@@ -67,6 +69,7 @@ function AuthContextProvider({ children }) {
     const value = {
         authData,
         setAuthData,
+        isUserLoggedIn,
         login,
         createAccount,
         logOut

--- a/dashboard-ui/src/context/authProvider.js
+++ b/dashboard-ui/src/context/authProvider.js
@@ -33,6 +33,7 @@ function AuthContextProvider({ children }) {
             localStorage.setItem(AUTH_DATA_LS_KEY, JSON.stringify(authData));
             queryClient.invalidateQueries(queryKeys.USER_DATA);
             setAuthData(authData);
+            history.push('/');
         }
 
         return errorMessage;

--- a/dashboard-ui/src/pages/Home.test.js
+++ b/dashboard-ui/src/pages/Home.test.js
@@ -1,23 +1,11 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { QueryClient, QueryClientProvider } from 'react-query';
 import { MemoryRouter } from 'react-router-dom';
 
 import { AuthContextProvider } from '../context/authProvider';
+import { createQueryWrapper } from '../testUtils';
 import Home from './Home';
-
-const createQueryWrapper = children => {
-    // creates a new QueryClient instance for each test
-    const queryClient = new QueryClient({
-        defaultOptions: {
-            queries: {
-                retry: false
-            }
-        }
-    });
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
-};
 
 it('should render view with club data fetched from backend', async () => {
     render(

--- a/dashboard-ui/src/pages/SquadHub.js
+++ b/dashboard-ui/src/pages/SquadHub.js
@@ -1,12 +1,19 @@
+import { Redirect } from 'react-router-dom';
+
 import SquadHubView from '../views/SquadHubView';
 import StyledLoadingCircle from '../components/StyledLoadingCircle';
 
+import { useCurrentClub } from '../context/clubProvider';
 import useSquadHubData from '../hooks/useSquadHubData';
 import useAddNewPlayer from '../hooks/useAddNewPlayer';
 
 import AddPlayer from '../widgets/AddPlayer';
 
 const SquadHub = () => {
+    const { currentClubId } = useCurrentClub();
+    if (!currentClubId) {
+        return <Redirect to='/'/>;
+    }
     const { addNewPlayerAction: addNewPlayerAciton } = useAddNewPlayer();
     const addPlayerWidget = <AddPlayer addPlayerAction={addNewPlayerAciton} />;
     const { isLoading, data: squadHubData } = useSquadHubData();

--- a/dashboard-ui/src/pages/SquadHub.test.js
+++ b/dashboard-ui/src/pages/SquadHub.test.js
@@ -1,0 +1,59 @@
+import { render } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router-dom';
+
+import { useCurrentClub } from '../context/clubProvider';
+import { AuthContextProvider } from '../context/authProvider';
+import SquadHub from './SquadHub';
+import { createQueryWrapper } from '../testUtils';
+
+jest.mock('../context/clubProvider.js', () => ({
+    ...jest.requireActual('../context/clubProvider.js'),
+    useCurrentClub: jest.fn()
+}));
+
+let history;
+beforeEach(() => {
+    history = createMemoryHistory({initialEntries: ['/squadHub']});
+    jest.resetAllMocks();
+});
+
+it('redirects to home page if a club is not selected', () => {
+    // setup
+    useCurrentClub.mockReturnValue({ currentClubId: null });
+
+    // execute
+    render(
+        <Router history={history}>
+            {createQueryWrapper(
+                <AuthContextProvider>
+                    <SquadHub />
+                </AuthContextProvider>
+            )}
+        </Router>
+    );
+
+    // assert
+    expect(useCurrentClub).toBeCalled();
+    expect(history.location.pathname).toBe('/');
+});
+
+it('does not redirect to home page if a club is selected', () => {
+    // setup
+    useCurrentClub.mockReturnValue({ currentClubId: 'fakeClubId' });
+
+    // execute
+    render(
+        <Router history={history}>
+            {createQueryWrapper(
+                <AuthContextProvider>
+                    <SquadHub />
+                </AuthContextProvider>
+            )}
+        </Router>
+    );
+
+    // assert
+    expect(useCurrentClub).toBeCalled();
+    expect(history.location.pathname).not.toBe('/');
+});

--- a/dashboard-ui/src/pages/UserAuth.js
+++ b/dashboard-ui/src/pages/UserAuth.js
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Redirect, Route, Switch, useRouteMatch } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 import SignIn from '../components/SignIn';
@@ -9,16 +9,18 @@ import useForm from '../hooks/useForm';
 import { useUserAuth } from '../context/authProvider';
 
 export default function UserAuth({ classes }) {
+    const { path } = useRouteMatch();
     return (
         <div className={classes.content}>
             <div className={classes.formContainer}>
                 <Switch>
-                    <Route exact path='/'>
+                    <Route path={`${path}/signIn`}>
                         <SignInContainer />
                     </Route>
-                    <Route path='/signUp'>
+                    <Route path={`${path}/signUp`}>
                         <SignUpContainer />
                     </Route>
+                    <Redirect to='/' />
                 </Switch>
             </div>
         </div>

--- a/dashboard-ui/src/routing/PrivateRoute.js
+++ b/dashboard-ui/src/routing/PrivateRoute.js
@@ -21,6 +21,7 @@ export default function PrivateRoute({ component: Component, componentProps, ...
 }
 
 PrivateRoute.propTypes = {
-    component: PropTypes.node,
+    // TODO: figure out what should be the proptype for this
+    component: PropTypes.any,
     componentProps: PropTypes.object
 };

--- a/dashboard-ui/src/routing/PrivateRoute.js
+++ b/dashboard-ui/src/routing/PrivateRoute.js
@@ -1,25 +1,26 @@
 import { Route, Redirect } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import { useUserAuth } from '../context/authProvider';
 
-import { useCurrentClub } from '../context/clubProvider';
-
-export default function PrivateRoute({ component: Component, ...rest }) {
+export default function PrivateRoute({ component: Component, componentProps, ...rest }) {
     // TODO: pass a access flag instead of tight coupling with club page visibility logic
-    const { currentClubId } = useCurrentClub();
+    const { isUserLoggedIn } = useUserAuth();
     return (
         <Route
             {...rest}
-            render={() => {
-                if (currentClubId) {
-                    return <Component />;
+            render={props => {
+                if (isUserLoggedIn()) {
+                    return <Component {...componentProps}/>;
                 }
 
-                return <Redirect to='/' />;
+                // eslint-disable-next-line react/prop-types
+                return <Redirect to={{ pathname: '/auth/signIn', state: { from: props.location } }}/>;
             }}
         />
     );
 }
 
 PrivateRoute.propTypes = {
-    component: PropTypes.node
+    component: PropTypes.node,
+    componentProps: PropTypes.object
 };

--- a/dashboard-ui/src/routing/PrivateRoute.test.js
+++ b/dashboard-ui/src/routing/PrivateRoute.test.js
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { Route, Router } from 'react-router-dom';
+
+import { AuthContextProvider, useUserAuth } from '../context/authProvider';
+import PrivateRoute from './PrivateRoute';
+import { createQueryWrapper } from '../testUtils';
+
+const PrivateComponent = () => <>Private!</>;
+const NonPrivateComponent = () => <>Not Private!</>;
+
+jest.mock('../context/authProvider.js', () => ({
+    ...jest.requireActual('../context/authProvider.js'),
+    useUserAuth: jest.fn()
+}));
+
+let history;
+beforeEach(() => {
+    jest.resetAllMocks();
+    history = createMemoryHistory({initialEntries: ['/private']});
+});
+
+test('user is redirected to signIn page if not authenticated', () => {
+    // setup
+    const isUserLoggedIn = jest.fn().mockReturnValue(false);
+    useUserAuth.mockReturnValue({ isUserLoggedIn });
+
+    // execute
+    render(
+        <Router history={history}>
+            {createQueryWrapper(
+                <AuthContextProvider>
+                    <PrivateRoute exact path='/private' component={PrivateComponent} />
+                    <Route exact path='/auth/signIn' component={NonPrivateComponent} />
+                </AuthContextProvider>
+            )}
+        </Router>
+    );
+
+    // assert
+    expect(isUserLoggedIn).toBeCalled();
+    expect(history.location.pathname).toBe('/auth/signIn');
+    expect(screen.queryByText('Not Private!')).toBeInTheDocument();
+    expect(screen.queryByText('Private!')).not.toBeInTheDocument();
+});
+
+test('user is not redirected to signIn page if authenticated', () => {
+    // setup
+    const isUserLoggedIn = jest.fn().mockReturnValue(true);
+    useUserAuth.mockReturnValue({ isUserLoggedIn });
+
+    // execute
+    render(
+        <Router history={history}>
+            {createQueryWrapper(
+                <AuthContextProvider>
+                    <PrivateRoute exact path='/private' component={PrivateComponent} />
+                    <Route exact path='/auth/signIn' component={NonPrivateComponent} />
+                </AuthContextProvider>
+            )}
+        </Router>
+    );
+
+    // assert
+    expect(isUserLoggedIn).toBeCalled();
+    expect(history.location.pathname).not.toBe('/auth/signIn');
+    expect(screen.queryByText('Not Private!')).not.toBeInTheDocument();
+    expect(screen.queryByText('Private!')).toBeInTheDocument();
+});

--- a/dashboard-ui/src/stories/utils/storyDataGenerators.js
+++ b/dashboard-ui/src/stories/utils/storyDataGenerators.js
@@ -234,7 +234,8 @@ export const getMatchPerformanceTableData = (numCompetitions) => ({
 export const getSquadHubPlayerData = (numPlayers, moraleList) => {
     return {
         players: [ ...Array(numPlayers) ].map((_0, idx) => ({
-            playerId: idx,
+            // TODO: either install uuidv4 or try using the fake uuid generator when faker migration is complete
+            playerId: idx.toString(),
             name: faker.name.findName(),
             nationality: _.sample(nationalityList),
             role: faker.hacker.noun(),

--- a/dashboard-ui/src/testUtils.js
+++ b/dashboard-ui/src/testUtils.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import { StylesProvider } from '@material-ui/core';
 import { render } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
 
 const snapshotFriendlyClassNameGenerator = (rule, styleSheet) => `${styleSheet.options.classNamePrefix}-${rule.key}`;
 
@@ -16,3 +17,15 @@ export const snapshotFriendlyRender = (ui, options = {}) =>
         wrapper: SnapshotFriendlyStylesProvider,
         ...options
     });
+
+export const createQueryWrapper = children => {
+    // creates a new QueryClient instance for each test
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: {
+                retry: false
+            }
+        }
+    });
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+};

--- a/dashboard-ui/src/views/SquadHubView.js
+++ b/dashboard-ui/src/views/SquadHubView.js
@@ -173,7 +173,10 @@ SquadHubView.propTypes = {
         PropTypes.shape({
             playerId: PropTypes.string,
             name: PropTypes.string,
-            nationality: PropTypes.string,
+            nationality: PropTypes.shape({
+                countryName: PropTypes.string,
+                flagURL: PropTypes.string
+            }),
             role: PropTypes.string,
             wages: PropTypes.number,
             form: PropTypes.arrayOf(PropTypes.number),


### PR DESCRIPTION
## Motivation and Context
There were a lot of issues with redirection and page refresh. For instance, logging out would update the URL in the address bar but would not re-render the associated component. Also, refreshing the page when viewing the squad hub would redirect the user to the home page of the dashboard. 

In this PR, these issues have been resolved by -
* Leveraging the presence of the `authToken` instead of the user data (fetched only when a valid `authToken` was present) to toggle between pages requiring authentication and those that did not.
* Encapsulating the routes requiring authentication inside the _PrivateRoute_ component. The very specific logic of Squad Hub redirection was removed from it as a result.
* Maintaining a coherent routes hierarchy with a parent container for the auth and dashboard pages.
* Isolating the Squad Hub redirection within the component itself by redirecting to the root route/path if a club context is not currently selected from the dashboard home page.

This resolves #110,

## How Has This Been Tested?
A couple of tests have been added to -
* Verify the updated behavior of the _PrivateRoute_ component.
* Verify the redirection logic injected into _SquadHub_ component.

## Types of changes
<!--- What types of changes does the code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
