### PR TITLE
Fix bug with updating club context provider when rendering club component

### DIFF
--- a/dashboard-ui/src/pages/Club.js
+++ b/dashboard-ui/src/pages/Club.js
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { useClubData } from '../hooks/useClubData';
@@ -11,12 +12,14 @@ export default function Club() {
     const { clubId } = useParams();
     const { isLoading, data: clubData } = useClubData(clubId);
 
+    useEffect(() => {
+        if(clubData && clubData.id !== currentClubId) {
+            setCurrentClubId(clubData.id);
+        }
+    });
+
     if (isLoading) {
         return <StyledLoadingCircle />;
-    }
-
-    if(clubData && clubData.id !== currentClubId) {
-        setCurrentClubId(clubData.id);
     }
 
     return <ClubPageView club={clubData} />;


### PR DESCRIPTION
## Motivation and Context
There was a warning being logged in the console whenever the user navigates to the club page view from the home page. 
```
 Cannot update a component (`ClubContextProvider`) while rendering a different component (`Club`).
```
This was a warning recently added by the React team. More details [here](https://reactjs.org/blog/2020/02/26/react-v16.13.0.html#new-warnings). The reasoning is simple - the _ClubContextProvider_ component's state was being updated from inside the _Club_ component when the `currentClubId` setter is being run. This is effectively a side-effect since one component is updating another component that is not directly related to it (parent or child). It is recommended to put this kind of side-effect inside the `useEffect` hook if it is intentional which has been done in this PR.

This PR resolves #111 

## How Has This Been Tested?
No tests updated since it is effectively a refactor.

## Types of changes
<!--- What types of changes does the code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
