### PR TITLE
SquadHub page redirects to Home page on first load.

### DIFF
--- a/dashboard-ui/src/hooks/useBoardObjectivesForClubData.js
+++ b/dashboard-ui/src/hooks/useBoardObjectivesForClubData.js
@@ -1,15 +1,13 @@
 import { useQuery } from 'react-query';
 import { queryKeys } from '../constants';
 import { useUserAuth } from '../context/authProvider';
-import { useCurrentClub } from '../context/clubProvider';
 import { fetchAllBoardObjectivesForClub } from '../clients/BoardObjectiveClient';
 
-export default function() {
+export default function(clubId) {
     const { authData } = useUserAuth();
-    const { currentClubId } = useCurrentClub();
 
     const { isLoading, data: boardObjectivesForClubData } = useQuery(
-        [queryKeys.ALL_BOARD_OBJECTIVES, currentClubId],
+        [queryKeys.ALL_BOARD_OBJECTIVES, clubId],
         fetchAllBoardObjectivesForClub,
         { meta: { authData } }
     );

--- a/dashboard-ui/src/pages/Club.js
+++ b/dashboard-ui/src/pages/Club.js
@@ -13,8 +13,9 @@ export default function Club() {
     const { isLoading, data: clubData } = useClubData(clubId);
 
     useEffect(() => {
-        if(clubData && clubData.id !== currentClubId) {
-            setCurrentClubId(clubData.id);
+        // update the currentClubId only when the clubId param in the url changes
+        if (currentClubId != clubId) {
+            setCurrentClubId(clubId);
         }
     }, []);
 

--- a/dashboard-ui/src/pages/SquadHub.js
+++ b/dashboard-ui/src/pages/SquadHub.js
@@ -14,6 +14,7 @@ const SquadHub = () => {
     if (!currentClubId) {
         return <Redirect to='/'/>;
     }
+
     const { addNewPlayerAction: addNewPlayerAction } = useAddNewPlayer();
     const addPlayerWidget = <AddPlayer addPlayerAction={addNewPlayerAction} />;
     const { isLoading, data: squadHubData } = useSquadHubData();

--- a/dashboard-ui/src/views/ClubPageView.js
+++ b/dashboard-ui/src/views/ClubPageView.js
@@ -12,8 +12,7 @@ import { MONTHS } from '../constants';
 import useBoardObjectivesForClubData from '../hooks/useBoardObjectivesForClubData';
 import StyledLoadingCircle from '../components/StyledLoadingCircle';
 import useAddNewBoardObjective from '../hooks/useAddNewBoardObjective';
-import { Redirect } from 'react-router-dom';
-import { useCurrentClub } from '../context/clubProvider';
+import { useParams } from 'react-router-dom';
 
 export default function ClubPageView({ club }) {
     return (
@@ -40,11 +39,9 @@ export default function ClubPageView({ club }) {
 }
 
 const BoardObjectivesContainer = () => {
-    const { currentClubId } = useCurrentClub();
-    if (!currentClubId) {
-        return <Redirect to='/' />;
-    }
-    const { addNewBoardObjectiveAction } = useAddNewBoardObjective();
+    const { clubId } = useParams();
+
+    const { addNewBoardObjectiveAction } = useAddNewBoardObjective(clubId);
     const { isLoading, data: boardObjectiveForClubData } = useBoardObjectivesForClubData();
 
     if (isLoading) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The reason this was happening was a bad `useEffect` hook. In this [hook](https://github.com/Spider101/football-stats-dashboard/blob/master/dashboard-ui/src/pages/Club.js#L19), the dependency array was empty even though the logic inside it depended on the `clubData` variable. As a result, it only ran once and usually `clubData` was not populated (_undefined_ or _null_) at this point and so the setter for `currentClubId` would never run. Due to this, when the squad hub page would load, it would redirect back to the user home page because `currentClubId` would be undefined. So, in this PR, I decided to simplify the logic and remove the dependency on the loading of the `clubData` variable and just set the `currentClubId` from the `clubId` param in the URL on page load.

A similar issue was happening on the club home page when loading the board objectives. I was unnecessarily using the _clubContextProvider_ to get the clubId for making the call to fetch all board objectives associated with a club. Instead, in this PR, I updated the logic to grab the club ID from the param in the URL instead and removed the redundant redirection logic. 

This fixes #161 

## How Has This Been Tested?
<!--- Please describe in detail the changes that have been tested. -->
<!--- Include scenarios covered and coverage details if possible. -->
Manually tested by running the server locally.

## Types of changes
<!--- What types of changes does the code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
