### PR TITLE
Add 409 conflict check for board objective resource

### DIFF
--- a/dashboard-server/src/main/java/com/footballstatsdashboard/resources/BoardObjectiveResource.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/resources/BoardObjectiveResource.java
@@ -101,7 +101,8 @@ public class BoardObjectiveResource {
             LOGGER.info("updateBoardObjective() request for board objective with ID: {}", boardObjectiveId);
         }
 
-        // the board objective ID in the path param can be considered a proxy for the ID in the corresponding entity
+        // verify that board objective id in the incoming request matches with the id in the existing data
+        // the board objective ID in the path param can be considered a proxy for the corresponding entity
         // stored in the database (assuming it exists)
         if (!boardObjectiveId.equals(incomingBoardObjective.getId())) {
             String errorMessage = String.format(

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/resources/BoardObjectiveResource.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/resources/BoardObjectiveResource.java
@@ -101,6 +101,16 @@ public class BoardObjectiveResource {
             LOGGER.info("updateBoardObjective() request for board objective with ID: {}", boardObjectiveId);
         }
 
+        // the board objective ID in the path param can be considered a proxy for the ID in the corresponding entity
+        // stored in the database (assuming it exists)
+        if (!boardObjectiveId.equals(incomingBoardObjective.getId())) {
+            String errorMessage = String.format(
+                    "Incoming board objective ID: %s does not match ID of existing board objective entity: %s.",
+                    incomingBoardObjective.getId(), boardObjectiveId);
+            LOGGER.error(errorMessage);
+            throw new ServiceException(HttpStatus.CONFLICT_409, errorMessage);
+        }
+
         // TODO: 13/04/22 move the entity existence check to DAO layer so we don't have to fetch the entire entity just
         //  to check that it exists. Also add a belongs to check after splitting it since it is encapsulated inside the
         //  getClub call at the moment

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/resources/ClubResource.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/resources/ClubResource.java
@@ -96,6 +96,17 @@ public class ClubResource {
             LOGGER.info("updateClub() request for club with ID: {}", existingClubId);
         }
 
+        // verify that club id in the incoming request matches with the id in the existing data
+        // the club ID in the path param can be considered a proxy for the corresponding persisted entity's ID
+        if (!existingClubId.equals(incomingClub.getId())) {
+            String errorMessage = String.format(
+                    "Incoming club entity ID: %s does not match ID of existing club entity %s.",
+                    incomingClub.getId(), existingClubId
+            );
+            LOGGER.error(errorMessage);
+            throw new ServiceException(HttpStatus.CONFLICT_409, errorMessage);
+        }
+
         // TODO: 26/04/22 change this to a 422 - invalid club logo file key; update tests
         if (!this.fileUploadService.doesFileExist(incomingClub.getLogo())) {
             String errorMessage = "No file found for club logo image with key: " + incomingClub.getLogo();
@@ -104,16 +115,6 @@ public class ClubResource {
         }
 
         Club existingClub = this.clubService.getClub(existingClubId, user.getId());
-
-        // TODO: 26/04/22 this is a dumb check; get rid of this scenario; update tests
-        if (!existingClub.getId().equals(incomingClub.getId())) {
-            String errorMessage = String.format(
-                    "Incoming club entity ID: %s does not match ID of existing club entity %s.",
-                    incomingClub.getId(), existingClub.getId()
-            );
-            LOGGER.error(errorMessage);
-            throw new ServiceException(HttpStatus.CONFLICT_409, errorMessage);
-        }
 
         Club updatedClub = this.clubService.updateClub(incomingClub, existingClub, existingClubId);
         return Response.ok().entity(updatedClub).build();

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/resources/PlayerResource.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/resources/PlayerResource.java
@@ -89,18 +89,18 @@ public class PlayerResource {
             LOGGER.info("updatePlayer() request for player with ID: {}", playerId.toString());
         }
 
-        Player existingPlayer = this.playerService.getPlayer(playerId);
-
-        // TODO: 26/04/22 this is a dumb check, remove this scenario; update tests
-        // verify that player id matches between the existing and incoming data
-        if (!existingPlayer.getId().equals(incomingPlayer.getId())) {
+        // verify that player id in the incoming request matches with the id in the existing data
+        // the player ID in the path param can be considered a proxy for the corresponding persisted entity's ID
+        if (!playerId.equals(incomingPlayer.getId())) {
             String errorMessage = String.format(
-                    "Incoming player ID: %s does not match ID of existing player entity in couchbase: %s.",
-                    incomingPlayer.getId(), existingPlayer.getId()
+                    "Incoming player ID: %s does not match ID of existing player entity: %s.",
+                    incomingPlayer.getId(), playerId
             );
             LOGGER.error(errorMessage);
             throw new ServiceException(HttpStatus.CONFLICT_409, errorMessage);
         }
+
+        Player existingPlayer = this.playerService.getPlayer(playerId);
 
         // verify that the current user has access to the player they are trying to update
         // since a player cannot belong to more than one club, we can transitively check the user's access to the player

--- a/dashboard-server/src/main/resources/api/api.raml
+++ b/dashboard-server/src/main/resources/api/api.raml
@@ -73,6 +73,10 @@ securitySchemes:
           body:
             application/json:
               example: !include examples/player-response-404.json
+        409:
+          description: |
+            conflict because the entity ID in the incoming data doesn't match the ID for the corresponding entity
+            in the database
         422:
           description: unprocessable entity when player roles or attributes are missing
     delete:

--- a/dashboard-server/src/main/resources/api/api.raml
+++ b/dashboard-server/src/main/resources/api/api.raml
@@ -293,6 +293,10 @@ securitySchemes:
                   examples:
                     boardObjective: !include examples/board-objective-response-404.json
                     club: !include examples/club-response-404.json
+            409:
+              description: |
+                conflict because the entity ID in the incoming data doesn't match the ID for the corresponding entity
+                in the database
         delete:
           description: delete the board objective data for a club on the basis of the board objective ID
           securedBy: [access_token]

--- a/dashboard-server/src/main/resources/api/api.raml
+++ b/dashboard-server/src/main/resources/api/api.raml
@@ -208,6 +208,10 @@ securitySchemes:
           body:
             application/json:
               example: !include examples/club-response-404.json
+        409:
+          description: |
+            conflict because the entity ID in the incoming data doesn't match the ID for the corresponding entity
+            in the database
         422:
           description: unprocessable entity when club name, income or expenditure data is missing in the request
     delete:

--- a/dashboard-server/src/main/resources/api/examples/board-objective-update-request.json
+++ b/dashboard-server/src/main/resources/api/examples/board-objective-update-request.json
@@ -1,4 +1,5 @@
 {
+  "id": "e6d69f9a-ae65-48fd-86ad-0bf7cc28cb35",
   "title": "A board objective title",
   "description": "A board objective description",
   "isCompleted": false

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/BoardObjectiveResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/BoardObjectiveResourceTest.java
@@ -333,13 +333,14 @@ public class BoardObjectiveResourceTest {
         BoardObjective incomingBoardObjective = BoardObjectiveDataProvider.BoardObjectiveBuilder.builder().build();
 
         // execute
-        assertThrows(ServiceException.class,
+        ServiceException serviceException = assertThrows(ServiceException.class,
                 () -> boardObjectiveResource.updateBoardObjective(userPrincipal, UUID.randomUUID(),
                         existingBoardObjectiveId, incomingBoardObjective));
 
         // assert
         verify(clubService, never()).getClub(any(), any());
         verify(boardObjectiveService, never()).updateBoardObjective(any(), any(), any());
+        assertEquals(HttpStatus.CONFLICT_409, serviceException.getResponseStatus());
     }
 
     /**

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/BoardObjectiveResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/BoardObjectiveResourceTest.java
@@ -233,7 +233,9 @@ public class BoardObjectiveResourceTest {
         // setup
         UUID existingClubId = UUID.randomUUID();
         UUID existingBoardObjectiveId = UUID.randomUUID();
-        BoardObjective incomingBoardObjective = BoardObjectiveDataProvider.BoardObjectiveBuilder.builder().build();
+        BoardObjective incomingBoardObjective = BoardObjectiveDataProvider.BoardObjectiveBuilder.builder()
+                .withExistingId(existingBoardObjectiveId)
+                .build();
         BoardObjective updatedBoardObjectiveBase = BoardObjectiveDataProvider.BoardObjectiveBuilder.builder()
                 .withExistingId(existingBoardObjectiveId)
                 .withClubId(existingClubId)
@@ -280,7 +282,9 @@ public class BoardObjectiveResourceTest {
         UUID inaccessibleClubId = UUID.randomUUID();
         when(clubService.getClub(eq(inaccessibleClubId), eq(userPrincipal.getId())))
                 .thenThrow(new ServiceException(HttpStatus.FORBIDDEN_403, "User does not have access to club!"));
-        BoardObjective incomingBoardObjective = BoardObjectiveDataProvider.BoardObjectiveBuilder.builder().build();
+        BoardObjective incomingBoardObjective = BoardObjectiveDataProvider.BoardObjectiveBuilder.builder()
+                .withExistingId(existingBoardObjectiveId)
+                .build();
 
         // execute
         assertThrows(ServiceException.class,
@@ -303,7 +307,9 @@ public class BoardObjectiveResourceTest {
         UUID nonExistentClubId = UUID.randomUUID();
         when(clubService.getClub(eq(nonExistentClubId), eq(userPrincipal.getId())))
                 .thenThrow(new ServiceException(HttpStatus.NOT_FOUND_404, "No club found!"));
-        BoardObjective incomingBoardObjective = BoardObjectiveDataProvider.BoardObjectiveBuilder.builder().build();
+        BoardObjective incomingBoardObjective = BoardObjectiveDataProvider.BoardObjectiveBuilder.builder()
+                .withExistingId(boardObjectiveId)
+                .build();
 
         // execute
         assertThrows(ServiceException.class,
@@ -313,6 +319,26 @@ public class BoardObjectiveResourceTest {
         // assert
         verify(clubService).getClub(any(), any());
         verify(boardObjectiveService, never()).getBoardObjective(any(), any());
+        verify(boardObjectiveService, never()).updateBoardObjective(any(), any(), any());
+    }
+
+    /**
+     * given a board objective entity whose ID does not match the ID of the corresponding board objective stored in the
+     * database, tests the associated board objective data is not updated and a service exception is thrown instead.
+     */
+    @Test
+    public void updatedBoardObjectiveWhenBoardObjectiveIdDoesNotMatchExisting() {
+        // setup
+        UUID existingBoardObjectiveId = UUID.randomUUID();
+        BoardObjective incomingBoardObjective = BoardObjectiveDataProvider.BoardObjectiveBuilder.builder().build();
+
+        // execute
+        assertThrows(ServiceException.class,
+                () -> boardObjectiveResource.updateBoardObjective(userPrincipal, UUID.randomUUID(),
+                        existingBoardObjectiveId, incomingBoardObjective));
+
+        // assert
+        verify(clubService, never()).getClub(any(), any());
         verify(boardObjectiveService, never()).updateBoardObjective(any(), any(), any());
     }
 

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/ClubResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/ClubResourceTest.java
@@ -281,29 +281,19 @@ public class ClubResourceTest {
     public void updateClubWhenIncomingClubIdDoesNotMatchExisting() {
         // setup
         UUID existingClubId = UUID.randomUUID();
-        Club existingClub = ClubDataProvider.ClubBuilder.builder()
-                .isExisting(true)
-                .existingUserId(userPrincipal.getId())
-                .withId(existingClubId)
-                .withIncome()
-                .withExpenditure()
-                .build();
-        when(clubService.getClub(any(), any())).thenReturn(existingClub);
-
         UUID incorrectIncomingClubId = UUID.randomUUID();
         Club incomingClub = ClubDataProvider.ClubBuilder.builder()
                 .isExisting(false)
                 .withId(incorrectIncomingClubId)
                 .build();
 
-        when(fileUploadService.doesFileExist(eq(incomingClub.getLogo()))).thenReturn(true);
-
         // execute
         ServiceException serviceException = assertThrows(ServiceException.class,
                 () -> clubResource.updateClub(userPrincipal, existingClubId, incomingClub));
 
         // assert
-        verify(clubService).getClub(any(), any());
+        verify(fileUploadService, never()).doesFileExist(anyString());
+        verify(clubService, never()).getClub(any(), any());
         verify(clubService, never()).updateClub(any(), any(), any());
         assertEquals(HttpStatus.CONFLICT_409, serviceException.getResponseStatus());
     }

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/resources/PlayerResourceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/resources/PlayerResourceTest.java
@@ -361,19 +361,6 @@ public class PlayerResourceTest {
     public void updatePlayerWhenIncomingPlayerIdDoesNotMatchExisting() {
         // setup
         UUID existingPlayerId = UUID.randomUUID();
-        Player existingPlayer = PlayerDataProvider.PlayerBuilder.builder()
-                .isExistingPlayer(true)
-                .withId(existingPlayerId)
-                .withMetadata()
-                .withAbility()
-                .withRoles()
-                .withAttributes()
-                .build();
-        when(playerService.getPlayer(eq(existingPlayerId))).thenReturn(existingPlayer);
-
-        when(clubService.doesClubBelongToUser(eq(existingPlayer.getClubId()), eq(userPrincipal.getId())))
-                .thenReturn(true);
-
         UUID incomingPlayerId = UUID.randomUUID();
         Player incomingPlayer = PlayerDataProvider.PlayerBuilder.builder()
                 .isExistingPlayer(false)
@@ -388,7 +375,7 @@ public class PlayerResourceTest {
                 () -> playerResource.updatePlayer(userPrincipal, existingPlayerId, incomingPlayer));
 
         // assert
-        verify(playerService).getPlayer(any());
+        verify(playerService, never()).getPlayer(any());
         verify(clubService, never()).doesClubBelongToUser(any(), any());
         verify(playerService, never()).updatePlayer(any(), any(), any());
         assertEquals(HttpStatus.CONFLICT_409, serviceException.getResponseStatus());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Realized that the 409 conflict checks are needed to make sure the data being updated matches the entity based on the ID in the URL. Hence, removed the TODOs suggesting that the checks be removed and updated the API doc to include the 409 response for the player and club resources.
- Realized that the entity ID in the path param for the URL can serve as a proxy for the ID attached to the entity stored in the database and therefore, there is no need to fetch the data to run the conflict check. The ID in the incoming entity can be checked against the ID in the path param instead. Updated the club and player resources to do so.
- Added similar checks and unit tests for the board objective resource as well.

## How Has This Been Tested?
<!--- Please describe in detail the changes have been tested. -->
<!--- Include scenarios covered and coverage details if possible. -->
Added new unit tests for the scenario mentioned.

## Types of changes
<!--- What types of changes does the code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring
