### PR TITLE
Fix bug with custom tooltip

### DIFF
--- a/dashboard-ui/src/components/AbilityProgressChart.js
+++ b/dashboard-ui/src/components/AbilityProgressChart.js
@@ -12,12 +12,18 @@ export default function AbilityProgressChart({ abilityData }) {
     const theme = useTheme();
 
     const chartData = transformAbilityData(abilityData.history);
+
     return (
         <ResponsiveContainer width='100%' height={500}>
             <BarChart data={chartData} barSize={50}>
-                <XAxis axisLine={false} tickLine={false} tickFormatter={number => MONTHS[number]}/>
+                <XAxis
+                    axisLine={false}
+                    tickLine={false}
+                    tickFormatter={number => MONTHS[number]}
+                    domain={['0', '11']}
+                />
                 <YAxis axisLine={false} tickLine={false} />
-                <Tooltip content={<CustomToolTip />}/>
+                <Tooltip content={<CustomToolTip />} cursor={false}/>
                 <CartesianGrid vertical={false} opacity={0.5} />
                 <Bar dataKey='playerAbility' fill={theme.palette.primary.main}/>
             </BarChart>

--- a/dashboard-ui/src/components/AttributeProgressChart.js
+++ b/dashboard-ui/src/components/AttributeProgressChart.js
@@ -21,6 +21,7 @@ export default function AttributeProgressChart({ attributeData }) {
     const attributeNames = attributeData.map(attribute => attribute.name);
     const chartData = transformAttributeData(attributeData);
     const { getPaletteColor } = buildChartPalette();
+
     return (
         <ResponsiveContainer height={500} width='100%'>
             <LineChart data={chartData}>
@@ -33,7 +34,7 @@ export default function AttributeProgressChart({ attributeData }) {
                         isAnimationActive={attributeNames.length <= CHART_ANIMATION_THRESHOLD}
                     />
                 ))}
-                <XAxis axisLine={false} tickFormatter={number => MONTHS[number]} tickLine={false} />
+                <XAxis axisLine={false} tickFormatter={number => MONTHS[number]} tickLine={false} domain={['0', '11']}/>
                 <YAxis axisLine={false} tickLine={false} />
                 <Tooltip content={<CustomToolTip />} />
                 <Legend />

--- a/dashboard-ui/src/stories/AbilityProgressChart.stories.js
+++ b/dashboard-ui/src/stories/AbilityProgressChart.stories.js
@@ -21,8 +21,14 @@ export default {
     }
 };
 
-export const Default = (args) => <AbilityProgressChart { ...args } />;
+const Template = args => <AbilityProgressChart { ...args } />;
 
-Default.args = {
+export const MultipleDataPoints = Template.bind({});
+MultipleDataPoints.args = {
     abilityData: getPlayerAbilityData()
+};
+
+export const SingleDataPoint = Template.bind({});
+SingleDataPoint.args = {
+    abilityData: getPlayerAbilityData(1)
 };

--- a/dashboard-ui/src/stories/AttributeProgressChart.stories.js
+++ b/dashboard-ui/src/stories/AttributeProgressChart.stories.js
@@ -23,7 +23,12 @@ export default {
 };
 
 const Template = args => <AttributeProgressChart { ...args } />;
-export const Default = Template.bind({});
-Default.args = {
+export const MultipleDataPoints = Template.bind({});
+MultipleDataPoints.args = {
     attributeData: getPlayerProgressionData(10, MAX_ATTR_VALUE)
+};
+
+export const SingleDataPoint = Template.bind({});
+SingleDataPoint.args = {
+    attributeData: getPlayerProgressionData(10, MAX_ATTR_VALUE, 1)
 };

--- a/dashboard-ui/src/stories/utils/storyDataGenerators.js
+++ b/dashboard-ui/src/stories/utils/storyDataGenerators.js
@@ -197,16 +197,16 @@ export const getPlayerData = (attributeNamesList, hasHistory = false) => {
     };
 };
 
-export const getPlayerProgressionData = (numAttributes, maxValue) => {
+export const getPlayerProgressionData = (numAttributes, maxValue, numMonths = NUM_MONTHS) => {
     return [ ...Array(numAttributes) ].map(() => ({
         name: faker.hacker.noun(),
-        history: [...Array(NUM_MONTHS)].map(() => faker.datatype.number(maxValue))
+        history: [...Array(numMonths)].map(() => faker.datatype.number(maxValue))
     }));
 };
 
-export const getPlayerAbilityData = () => ({
+export const getPlayerAbilityData = (numMonths = NUM_MONTHS) => ({
     name: 'Player Ability',
-    history: [...Array(NUM_MONTHS)].map(() => faker.datatype.number(MAX_OVERALL_VALUE))
+    history: [...Array(numMonths)].map(() => faker.datatype.number(MAX_OVERALL_VALUE))
 });
 
 export const getCardWithChartData = (dataKeys, numDataPoints, maxValue) =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The custom tooltip component was erroring out due to unexpected values. This happened because when the X-axis has one or fewer data points, _Recharts_ adds an `auto` value to its possible values. The tooltip did not know how to display this value and hence threw an error. To fix this, it was suggested to either fill the dataset with empty values for all expected data points on the x-axis or specify the range of values the X-axis can take. I chose to do the latter.

Additionally, I removed the background hover styling for bar charts.

Also, this issue seems to only happen with line and bar charts. I verified that the polar and custom vertical charts work correctly with a single point of data.

This PR closes #184 

**NOTE**: a downside of this fix is that the chart is now center-aligned when there is only one data point.

## How Has This Been Tested?
<!--- Please describe in detail the changes that have been tested. -->
<!--- Include scenarios covered and coverage details if possible. -->
Added stories to replicate the bug and verified manually that the fix works. Not possible to add tests due to existing incompatibility issues with jest and recharts.

## Types of changes
<!--- What types of changes does the code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
