### PR TITLE
Implement belongs-to functionality for player and club Couchbase DAOs

### DIFF
--- a/dashboard-server/src/main/java/com/footballstatsdashboard/db/couchbase/PlayerCouchbaseDAO.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/db/couchbase/PlayerCouchbaseDAO.java
@@ -3,7 +3,10 @@ package com.footballstatsdashboard.db.couchbase;
 import com.couchbase.client.core.error.DocumentNotFoundException;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
+import com.couchbase.client.java.json.JsonObject;
 import com.couchbase.client.java.kv.GetResult;
+import com.couchbase.client.java.query.QueryOptions;
+import com.couchbase.client.java.query.QueryResult;
 import com.footballstatsdashboard.api.model.Player;
 import com.footballstatsdashboard.db.IPlayerEntityDAO;
 import com.footballstatsdashboard.db.key.CouchbaseKeyProvider;
@@ -11,6 +14,7 @@ import com.footballstatsdashboard.db.key.ResourceKey;
 import io.dropwizard.setup.Environment;
 
 import javax.persistence.EntityNotFoundException;
+import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
 
@@ -60,7 +64,24 @@ public class PlayerCouchbaseDAO extends CouchbaseDAO implements IPlayerEntityDAO
 
     @Override
     public boolean doesEntityBelongToUser(UUID entityId, UUID userId) {
-        // TODO: 02/05/22 implement this when the couchbase server is ready
+        String query = String.format("SELECT club.userId FROM `%s` AS player JOIN `%s` AS club" +
+                        " ON player.clubId = club.id" +
+                        " WHERE club.type = 'Club' AND player.id = $playerId",
+                this.getCouchbaseBucket().name(), this.getCouchbaseBucket().name());
+
+        QueryOptions queryOptions = QueryOptions.queryOptions().parameters(
+                JsonObject.create().put("playerId", entityId.toString())
+        );
+        QueryResult queryResult = this.getCouchbaseCluster().query(query, queryOptions);
+        List<JsonObject> resultRows = queryResult.rowsAsObject();
+
+        if (resultRows.size() == 1) {
+            UUID userIdAssociatedWithPlayer = UUID.fromString(resultRows.get(0).getString("userId"));
+            return userIdAssociatedWithPlayer.equals(userId);
+        }
+
+        // TODO: 30/04/21 figure out a way to handle query result having more than one userId
+        //  (bad state; should not happen)
         return false;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR updates the Couchbase implementation of player and club DAOs to fill in missing functionality. Specifically, the method for checking if a club or a player belongs to the authenticated user before allowing them to perform crucial operations on them (like updating or deleting the documents).

## How Has This Been Tested?
<!--- Please describe in detail the changes that have been tested. -->
<!--- Include scenarios covered and coverage details if possible. -->
Tested locally via the API using Insomnia. I was able to -
* Delete a club belonging to the authenticated user (utilizes the belongs-to check)
* Delete a player belonging to the authenticated user (utilizes the belongs-to check)

## Types of changes
<!--- What types of changes does the code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
