### PR TITLE
Implement entity exists check for player and club DAOs

### DIFF
--- a/dashboard-server/src/main/java/com/footballstatsdashboard/db/IClubEntityDAO.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/db/IClubEntityDAO.java
@@ -11,4 +11,5 @@ public interface IClubEntityDAO extends IEntityDAO<Club> {
     List<ClubSummary> getClubSummariesForUser(UUID userId);
     List<SquadPlayer> getPlayersInClub(UUID clubId);
     boolean doesEntityBelongToUser(UUID entityId, UUID userId);
+    boolean doesEntityExist(UUID entityId);
 }

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/db/couchbase/ClubCouchbaseDAO.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/db/couchbase/ClubCouchbaseDAO.java
@@ -5,6 +5,7 @@ import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.json.JsonArray;
 import com.couchbase.client.java.json.JsonObject;
+import com.couchbase.client.java.kv.ExistsResult;
 import com.couchbase.client.java.kv.GetResult;
 import com.couchbase.client.java.kv.LookupInResult;
 import com.couchbase.client.java.query.QueryOptions;
@@ -89,7 +90,10 @@ public class ClubCouchbaseDAO extends CouchbaseDAO implements IClubEntityDAO {
 
     @Override
     public boolean doesEntityExist(UUID entityId) {
-        return false;
+        ResourceKey key = new ResourceKey(entityId);
+        String documentKey = this.keyProvider.getCouchbaseKey(key);
+        ExistsResult result = this.getCouchbaseBucket().defaultCollection().exists(documentKey);
+        return result.exists();
     }
 
     @Override

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/db/couchbase/ClubCouchbaseDAO.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/db/couchbase/ClubCouchbaseDAO.java
@@ -82,8 +82,15 @@ public class ClubCouchbaseDAO extends CouchbaseDAO implements IClubEntityDAO {
     public boolean doesEntityBelongToUser(UUID entityId, UUID userId) {
         ResourceKey key = new ResourceKey(entityId);
         String documentKey = this.keyProvider.getCouchbaseKey(key);
-        LookupInResult lookupInResult = this.getCouchbaseBucket().defaultCollection()
-                .lookupIn(documentKey, Collections.singletonList(get("userId")));
+        LookupInResult lookupInResult;
+
+        try {
+            lookupInResult = this.getCouchbaseBucket().defaultCollection()
+                    .lookupIn(documentKey, Collections.singletonList(get("userId")));
+        } catch (DocumentNotFoundException documentNotFoundException) {
+            throw new EntityNotFoundException(documentNotFoundException.getMessage());
+        }
+
         UUID userIdAssociatedWithClub = lookupInResult.contentAs(0, UUID.class);
         return userIdAssociatedWithClub.equals(userId);
     }

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/db/couchbase/ClubCouchbaseDAO.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/db/couchbase/ClubCouchbaseDAO.java
@@ -88,6 +88,11 @@ public class ClubCouchbaseDAO extends CouchbaseDAO implements IClubEntityDAO {
     }
 
     @Override
+    public boolean doesEntityExist(UUID entityId) {
+        return false;
+    }
+
+    @Override
     public List<ClubSummary> getClubSummariesForUser(UUID userId) {
         String query = String.format("SELECT club.id AS clubId, club.name, club.logo, club.createdDate FROM `%s` club" +
                 " WHERE club.type = 'Club' AND club.userId = $userId", this.getCouchbaseBucket().name());

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/db/couchbase/ClubCouchbaseDAO.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/db/couchbase/ClubCouchbaseDAO.java
@@ -105,7 +105,8 @@ public class ClubCouchbaseDAO extends CouchbaseDAO implements IClubEntityDAO {
 
     @Override
     public List<ClubSummary> getClubSummariesForUser(UUID userId) {
-        String query = String.format("SELECT club.id AS clubId, club.name, club.logo, club.createdDate FROM `%s` club" +
+        String query = String.format("SELECT club.id AS clubId, club.name, club.logo, club.createdDate" +
+                " FROM `%s` AS club" +
                 " WHERE club.type = 'Club' AND club.userId = $userId", this.getCouchbaseBucket().name());
         QueryOptions queryOptions = QueryOptions.queryOptions().parameters(
                 JsonObject.create().put("userId", userId.toString())

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/db/couchbase/PlayerCouchbaseDAO.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/db/couchbase/PlayerCouchbaseDAO.java
@@ -4,6 +4,7 @@ import com.couchbase.client.core.error.DocumentNotFoundException;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.json.JsonObject;
+import com.couchbase.client.java.kv.ExistsResult;
 import com.couchbase.client.java.kv.GetResult;
 import com.couchbase.client.java.query.QueryOptions;
 import com.couchbase.client.java.query.QueryResult;
@@ -87,7 +88,9 @@ public class PlayerCouchbaseDAO extends CouchbaseDAO implements IPlayerEntityDAO
 
     @Override
     public boolean doesEntityExist(UUID entityId) {
-        // TODO: 06/05/22 implement this when the couchbase server is ready
-        return false;
+        ResourceKey key = new ResourceKey(entityId);
+        String documentKey = this.keyProvider.getCouchbaseKey(key);
+        ExistsResult result = this.getCouchbaseBucket().defaultCollection().exists(documentKey);
+        return result.exists();
     }
 }

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/db/jdbi/ClubJdbiDAO.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/db/jdbi/ClubJdbiDAO.java
@@ -21,7 +21,6 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
 import javax.persistence.EntityNotFoundException;
-import javax.persistence.NoResultException;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
@@ -93,6 +92,11 @@ public class ClubJdbiDAO implements IClubEntityDAO {
         return this.clubDAO.findUserIdAssociatedWithClub(entityId.toString())
                 .map(userIdAssociatedWithClub -> userIdAssociatedWithClub.equals(userId.toString()))
                 .orElseThrow(EntityNotFoundException::new);
+    }
+
+    @Override
+    public boolean doesEntityExist(UUID entityId) {
+        return false;
     }
 
     public List<ClubSummary> getClubSummariesForUser(UUID userId) {

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/db/jdbi/ClubJdbiDAO.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/db/jdbi/ClubJdbiDAO.java
@@ -88,9 +88,11 @@ public class ClubJdbiDAO implements IClubEntityDAO {
 
     @Override
     public boolean doesEntityBelongToUser(UUID entityId, UUID userId) {
+        // since this is a simple look-up, inability to fetch the userId is only possible if the entity doesn't exist
+        // hence the EntityNotFoundException instead of the NoResultException
         return this.clubDAO.findUserIdAssociatedWithClub(entityId.toString())
                 .map(userIdAssociatedWithClub -> userIdAssociatedWithClub.equals(userId.toString()))
-                .orElseThrow(NoResultException::new);
+                .orElseThrow(EntityNotFoundException::new);
     }
 
     public List<ClubSummary> getClubSummariesForUser(UUID userId) {

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/db/jdbi/ClubJdbiDAO.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/db/jdbi/ClubJdbiDAO.java
@@ -96,7 +96,7 @@ public class ClubJdbiDAO implements IClubEntityDAO {
 
     @Override
     public boolean doesEntityExist(UUID entityId) {
-        return false;
+        return this.clubDAO.findById(entityId.toString()).isPresent();
     }
 
     public List<ClubSummary> getClubSummariesForUser(UUID userId) {

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
@@ -41,7 +41,7 @@ public class ClubService {
     public boolean doesClubBelongToUser(UUID clubId, UUID authorizedUserId) {
         try {
             return this.clubDAO.doesEntityBelongToUser(clubId, authorizedUserId);
-        } catch (NoResultException noResultException) {
+        } catch (EntityNotFoundException entityNotFoundException) {
             String errorMessage = String.format("No club entity found for ID: %s", clubId);
             LOGGER.error(errorMessage);
             throw new ServiceException(HttpStatus.NOT_FOUND_404, errorMessage);

--- a/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
+++ b/dashboard-server/src/main/java/com/footballstatsdashboard/services/ClubService.java
@@ -20,7 +20,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.persistence.EntityNotFoundException;
-import javax.persistence.NoResultException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -142,6 +141,12 @@ public class ClubService {
     }
 
     public void deleteClub(UUID clubId, UUID authorizedUserId) {
+        if (!this.clubDAO.doesEntityExist(clubId)) {
+            String errorMessage = String.format("No club entity found for ID: %s", clubId);
+            LOGGER.error(errorMessage);
+            throw new ServiceException(HttpStatus.NOT_FOUND_404, errorMessage);
+        }
+
         // ensure user has access to the club that is being requested to be deleted
         if (!this.doesClubBelongToUser(clubId, authorizedUserId)) {
             LOGGER.error("Club with ID: {} does not belong to user making request (ID: {})",

--- a/dashboard-server/src/test/java/com/footballstatsdashboard/services/ClubServiceTest.java
+++ b/dashboard-server/src/test/java/com/footballstatsdashboard/services/ClubServiceTest.java
@@ -634,14 +634,14 @@ public class ClubServiceTest {
     }
 
     /**
-     * given an invalid club id, tests that the NoResultException thrown by the DAO layer is handled and
+     * given an invalid club id, tests that the EntityNotFoundException thrown by the DAO layer is handled and
      * ServiceException is thrown instead
      */
     @Test
     public void deleteClubWhenClubDataDoesNotExist() {
         // setup
         UUID invalidClubId = UUID.randomUUID();
-        when(clubDAO.doesEntityBelongToUser(eq(invalidClubId), eq(userId))).thenThrow(NoResultException.class);
+        when(clubDAO.doesEntityBelongToUser(eq(invalidClubId), eq(userId))).thenThrow(EntityNotFoundException.class);
 
         // execute
         ServiceException serviceException = assertThrows(ServiceException.class,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR updates the Couchbase implementation of player and club DAOs to fill in missing functionality. Specifically, the method for checking if a club or a player exists before allowing the user to perform crucial operations on them (like deleting the entities). 
This also includes a bug fix wherein the correct exception is now thrown in the belongs-to check method in the club entity DAO.

## How Has This Been Tested?
<!--- Please describe in detail the changes that have been tested. -->
<!--- Include scenarios covered and coverage details if possible. -->
Updated UTs to account for the entity-exists check in the following scenarios:
* delete the club (happy path)
* delete the club when the club does not belong to the user
* delete the club when the club entity does not exist

I also tested the DAO implementations locally via the API using Insomnia.

## Types of changes
<!--- What types of changes does the code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
